### PR TITLE
Fix reply formatting and memory command visibility

### DIFF
--- a/TsDiscordBot.Core/Commands/MemoryCommandModule.cs
+++ b/TsDiscordBot.Core/Commands/MemoryCommandModule.cs
@@ -62,13 +62,13 @@ public class MemoryCommandModule: InteractionModuleBase<SocketInteractionContext
     }
 
     [SlashCommand("show-memories", "つむぎちゃんが覚えていること一覧を表示させる")]
-    private  async Task ShowMemories()
+    public async Task ShowMemories()
     {
         var guildId = Context.Guild.Id;
         LongTermMemory[] memories =
-        _databaseService.FindAll<LongTermMemory>(LongTermMemory.TableName)
-            .Where(x => x.GuildId == guildId)
-            .ToArray();
+            _databaseService.FindAll<LongTermMemory>(LongTermMemory.TableName)
+                .Where(x => x.GuildId == guildId)
+                .ToArray();
 
         StringBuilder builder = new();
 
@@ -76,6 +76,7 @@ public class MemoryCommandModule: InteractionModuleBase<SocketInteractionContext
         {
             builder.AppendLine($"ID = {memory.Id}: {memory.Content} by {memory.Author}");
         }
+
         await RespondAsync(builder.ToString());
     }
 }

--- a/TsDiscordBot.Core/HostedService/TsumugiService.cs
+++ b/TsDiscordBot.Core/HostedService/TsumugiService.cs
@@ -116,7 +116,7 @@ namespace TsDiscordBot.Core.HostedService
 
             if (reply is not null)
             {
-                body = $">> {reply.Author}({reply.Date}):{reply.Content}${body}";
+                body = $">> {reply.Author}({reply.Date}):{reply.Content}\n{body}";
             }
 
             author ??= message.Author.Username;


### PR DESCRIPTION
## Summary
- Correct reply quoting in TsumugiService to avoid stray dollar sign and separate reply with newline
- Expose `show-memories` slash command by making handler method public

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689c509b54b4832db8f7edacbc8ead71