### PR TITLE
fix: correct logger generics and slash command visibility

### DIFF
--- a/TsDiscordBot.Core/Commands/DiceCommandModule.cs
+++ b/TsDiscordBot.Core/Commands/DiceCommandModule.cs
@@ -11,7 +11,7 @@ public class DiceCommandModule: InteractionModuleBase<SocketInteractionContext>
     private readonly DatabaseService _databaseService;
     private readonly Random _rand = new();
 
-    public DiceCommandModule(ILogger<ReactionCommandModule> logger, DatabaseService databaseService)
+    public DiceCommandModule(ILogger<DiceCommandModule> logger, DatabaseService databaseService)
     {
         _logger = logger;
         _databaseService = databaseService;
@@ -23,7 +23,7 @@ public class DiceCommandModule: InteractionModuleBase<SocketInteractionContext>
         StringBuilder builder = new();
         string message = string.Empty;
 
-        int result = (_rand.Next() % 6);
+        int result = _rand.Next(6);
 
         string[] dice_characters =
         {

--- a/TsDiscordBot.Core/Commands/MemoryCommandModule.cs
+++ b/TsDiscordBot.Core/Commands/MemoryCommandModule.cs
@@ -1,3 +1,5 @@
+
+
 ﻿using System.Text;
 using Discord.Interactions;
 using Discord.WebSocket;
@@ -13,7 +15,7 @@ public class MemoryCommandModule: InteractionModuleBase<SocketInteractionContext
     private readonly DatabaseService _databaseService;
     private readonly OpenAIService _openAiService;
 
-    public MemoryCommandModule(ILogger<ReactionCommandModule> logger, DatabaseService databaseService,OpenAIService openAiService)
+    public MemoryCommandModule(ILogger<MemoryCommandModule> logger, DatabaseService databaseService, OpenAIService openAiService)
     {
         _logger = logger;
         _databaseService = databaseService;
@@ -62,7 +64,7 @@ public class MemoryCommandModule: InteractionModuleBase<SocketInteractionContext
     }
 
     [SlashCommand("show-memories", "つむぎちゃんが覚えていること一覧を表示させる")]
-    private  async Task ShowMemories()
+    public async Task ShowMemories()
     {
         var guildId = Context.Guild.Id;
         LongTermMemory[] memories =


### PR DESCRIPTION
## Summary
- fix logger type in memory and dice command modules
- expose `show-memories` as public slash command
- use unbiased random generation for `/dice`

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403  Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689c50ab7cf8832d9c28d615fe10b695