### PR TITLE
Add Dockerfile for .NET bot deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+**/bin
+**/obj
+.git
+.github
+.idea
+secret

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+# Build stage
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+
+# Copy the project files and restore dependencies
+COPY TsDiscordBot.Core/TsDiscordBot.Core.csproj TsDiscordBot.Core/
+COPY TsDiscordBot.Entry/TsDiscordBot.Entry.csproj TsDiscordBot.Entry/
+RUN dotnet restore TsDiscordBot.Entry/TsDiscordBot.Entry.csproj
+
+# Copy the remaining source code and publish the application
+COPY . .
+RUN dotnet publish TsDiscordBot.Entry/TsDiscordBot.Entry.csproj -c Release -o /app/publish
+
+# Runtime stage
+FROM mcr.microsoft.com/dotnet/runtime:8.0
+WORKDIR /app
+COPY --from=build /app/publish .
+
+ENTRYPOINT ["dotnet", "TsDiscordBot.Entry.dll"]


### PR DESCRIPTION
## Summary
- Add multi-stage Dockerfile to build and run the Discord bot
- Ignore build artifacts, git metadata, IDE files, and secrets in Docker context

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689c58d33460832d89aae49f47c1f44e