### PR TITLE
Add environment variable and config fallback for system prompt

### DIFF
--- a/TsDiscordBot.Core/Services/OpenAIService.cs
+++ b/TsDiscordBot.Core/Services/OpenAIService.cs
@@ -27,15 +27,25 @@ namespace TsDiscordBot.Core.Services
 
             _client = new(model: "gpt-5-nano", apiKey: apiKey);
 
-            _systemPrompt = string.Empty;
-            try
+            var systemPrompt = Environment.GetEnvironmentVariable("OPENAI_PROMPT");
+            if (string.IsNullOrWhiteSpace(systemPrompt))
             {
-                _systemPrompt = File.ReadAllText("_prompt.txt");
+                systemPrompt = config["open_ai_prompt"];
             }
-            catch
+
+            if (string.IsNullOrWhiteSpace(systemPrompt))
             {
-                //ignored.
+                try
+                {
+                    systemPrompt = File.ReadAllText("_prompt.txt");
+                }
+                catch
+                {
+                    systemPrompt = string.Empty;
+                }
             }
+
+            _systemPrompt = systemPrompt ?? string.Empty;
         }
 
         public string GetEducationPrompt(ulong guildId)


### PR DESCRIPTION
## Summary
- Retrieve OpenAI prompt from `OPENAI_PROMPT` environment variable
- Fallback to `_config` value `open_ai_prompt` and then `_prompt.txt`

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689c651f8c1c832d93977da700e36072