### PR TITLE
Log environment variable presence

### DIFF
--- a/TsDiscordBot.Core/Envs.cs
+++ b/TsDiscordBot.Core/Envs.cs
@@ -1,4 +1,6 @@
-﻿namespace TsDiscordBot.Core
+﻿using Microsoft.Extensions.Logging;
+
+namespace TsDiscordBot.Core
 {
     public static class Envs
     {
@@ -6,5 +8,17 @@
         public static string OPENAI_PROMPT => Environment.GetEnvironmentVariable(nameof(OPENAI_PROMPT)) ?? string.Empty;
         public static string DISCORD_TOKEN => Environment.GetEnvironmentVariable(nameof(DISCORD_TOKEN)) ?? string.Empty;
         public static string LITEDB_PATH => Environment.GetEnvironmentVariable(nameof(LITEDB_PATH)) ?? string.Empty;
+
+        public static void LogEnvironmentVariables()
+        {
+            Console.WriteLine(
+                "ENV present: OPENAI_API_KEY={0}, DISCORD_TOKEN={1}",
+                !string.IsNullOrWhiteSpace(OPENAI_API_KEY),
+                !string.IsNullOrWhiteSpace(DISCORD_TOKEN));
+
+            Console.WriteLine("ENV values: OPENAI_PROMPT={0}, LITEDB_PATH={1}",
+                OPENAI_PROMPT,
+                LITEDB_PATH);
+        }
     }
 }

--- a/TsDiscordBot.Entry/Program.cs
+++ b/TsDiscordBot.Entry/Program.cs
@@ -4,8 +4,12 @@ using Discord.WebSocket;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using TsDiscordBot.Core;
 using TsDiscordBot.Core.HostedService;
 using TsDiscordBot.Core.Services;
+
+// logging
+Envs.LogEnvironmentVariables();
 
 using IHost host = Host.CreateDefaultBuilder(args)
     .ConfigureAppConfiguration(config =>


### PR DESCRIPTION
## Summary
- add helper to log the presence of required environment variables and show prompt/db values
- log environment variable state on application startup

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689c7b677bd8832dae1894a94aa4eeed