### PR TITLE
Add configurable auto messaging

### DIFF
--- a/TsDiscordBot.Core/Commands/AutoMessageCommandModule.cs
+++ b/TsDiscordBot.Core/Commands/AutoMessageCommandModule.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Linq;
+using Discord.Interactions;
+using Discord.WebSocket;
+using Microsoft.Extensions.Logging;
+using TsDiscordBot.Core.Data;
+using TsDiscordBot.Core.Services;
+
+namespace TsDiscordBot.Core.Commands;
+
+public class AutoMessageCommandModule: InteractionModuleBase<SocketInteractionContext>
+{
+    private readonly ILogger _logger;
+    private readonly DatabaseService _databaseService;
+
+    public AutoMessageCommandModule(ILogger<AutoMessageCommandModule> logger, DatabaseService databaseService)
+    {
+        _logger = logger;
+        _databaseService = databaseService;
+    }
+
+    [SlashCommand("auto-message", "AIで会話を促す自動メッセージを設定します。")]
+    public async Task RegisterAutoMessage([Summary("t", "メッセージを送信する間隔(時間)")] int t = 1)
+    {
+        var channelId = Context.Channel.Id;
+        var guildId = Context.Guild.Id;
+
+        var existing = _databaseService.FindAll<AutoMessageChannel>(AutoMessageChannel.TableName)
+            .FirstOrDefault(x => x.ChannelId == channelId && x.GuildId == guildId);
+
+        if (existing is not null)
+        {
+            _databaseService.Delete(AutoMessageChannel.TableName, existing.Id);
+        }
+
+        var data = new AutoMessageChannel
+        {
+            GuildId = guildId,
+            ChannelId = channelId,
+            IntervalHours = t,
+            LastPostedUtc = DateTime.UtcNow
+        };
+
+        _databaseService.Insert(AutoMessageChannel.TableName, data);
+
+        await RespondAsync($"このチャンネルで{t}時間ごとにメッセージを送信するように設定したよ！");
+    }
+}

--- a/TsDiscordBot.Core/Data/AutoMessageChannel.cs
+++ b/TsDiscordBot.Core/Data/AutoMessageChannel.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace TsDiscordBot.Core.Data;
+
+public class AutoMessageChannel
+{
+    public const string TableName = "auto_message_channel";
+
+    public int Id { get; set; }
+    public ulong GuildId { get; set; }
+    public ulong ChannelId { get; set; }
+    public int IntervalHours { get; set; }
+    public DateTime LastPostedUtc { get; set; }
+}

--- a/TsDiscordBot.Core/HostedService/AutoMessageService.cs
+++ b/TsDiscordBot.Core/HostedService/AutoMessageService.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Discord.WebSocket;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using TsDiscordBot.Core.Data;
+using TsDiscordBot.Core.Services;
+
+namespace TsDiscordBot.Core.HostedService;
+
+public class AutoMessageService : BackgroundService
+{
+    private readonly DiscordSocketClient _client;
+    private readonly ILogger<AutoMessageService> _logger;
+    private readonly DatabaseService _databaseService;
+    private readonly OpenAIService _openAiService;
+
+    public AutoMessageService(DiscordSocketClient client, ILogger<AutoMessageService> logger,
+        DatabaseService databaseService, OpenAIService openAiService)
+    {
+        _client = client;
+        _logger = logger;
+        _databaseService = databaseService;
+        _openAiService = openAiService;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                var configs = _databaseService.FindAll<AutoMessageChannel>(AutoMessageChannel.TableName).ToArray();
+
+                foreach (var config in configs)
+                {
+                    var next = config.LastPostedUtc.AddHours(config.IntervalHours);
+                    if (DateTime.UtcNow >= next)
+                    {
+                        var guildId = config.GuildId;
+                        SocketTextChannel? channel = _client.GetChannel(config.ChannelId) as SocketTextChannel
+                            ?? _client.GetGuild(guildId)?.GetTextChannel(config.ChannelId);
+
+                        if (channel is not null)
+                        {
+                            var prompt = new OpenAIService.Message("会話を促す短いメッセージを作って", "system", DateTimeOffset.Now);
+                            var message = await _openAiService.GetResponse(guildId, prompt, Array.Empty<OpenAIService.Message>());
+                            await channel.SendMessageAsync(message);
+
+                            config.LastPostedUtc = DateTime.UtcNow;
+                            _databaseService.Update(AutoMessageChannel.TableName, config);
+                        }
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e, "Failed to send auto message");
+            }
+
+            await Task.Delay(TimeSpan.FromMinutes(1), stoppingToken);
+        }
+    }
+}

--- a/TsDiscordBot.Core/Services/DatabaseService.cs
+++ b/TsDiscordBot.Core/Services/DatabaseService.cs
@@ -72,6 +72,25 @@ public class DatabaseService : IDisposable
         }
     }
 
+    public void Update<T>(string tableName, T data)
+    {
+        if (_litedb is null)
+        {
+            _logger.LogError($"Failed to update DB path:{_databasePath} table name:{tableName}");
+            return;
+        }
+
+        try
+        {
+            var col = _litedb.GetCollection<T>(tableName);
+            _ = col.Update(data);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e,$"Failed to update DB path:{_databasePath} table name:{tableName}");
+        }
+    }
+
     public IEnumerable<T> FindAll<T>(string tableName)
     {
         if (_litedb is null)

--- a/TsDiscordBot.Entry/Program.cs
+++ b/TsDiscordBot.Entry/Program.cs
@@ -40,6 +40,7 @@ using IHost host = Host.CreateDefaultBuilder(args)
         services.AddHostedService<R18MessageCheckerService>();
         services.AddHostedService<NauAriService>();
         services.AddHostedService<TsumugiService>();
+        services.AddHostedService<AutoMessageService>();
     })
     .Build();
 


### PR DESCRIPTION
## Summary
- add `/auto-message` command to register channels and intervals for automatic messages
- persist channel, guild, interval, and last-posted timestamp for auto-messaging
- periodically send AI conversation prompts to configured channels and update last-posted time
- register the new auto message service in startup

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden; repository not signed)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_689c854d1f0c832dbe6c6bc356d9aa96