### PR TITLE
Add commands to view and overwrite auto message settings

### DIFF
--- a/TsDiscordBot.Core/Commands/AutoMessageCommandModule.cs
+++ b/TsDiscordBot.Core/Commands/AutoMessageCommandModule.cs
@@ -86,6 +86,86 @@ public class AutoMessageCommandModule: InteractionModuleBase<SocketInteractionCo
         await RespondAsync($"チャンネル<#{channelId}>で{startMessage}{t}時間ごとにメッセージを送信するように設定したよ！");
     }
 
+    [SlashCommand("show-auto-message", "AIで会話を促す自動メッセージの現在の設定を表示します。")]
+    public async Task ShowAutoMessage()
+    {
+        var guildId = Context.Guild.Id;
+
+        var existing = _databaseService
+            .FindAll<AutoMessageChannel>(AutoMessageChannel.TableName)
+            .FirstOrDefault(x => x.GuildId == guildId);
+
+        if (existing is null)
+        {
+            await RespondAsync("このサーバーでは自動メッセージは設定されていないよ！");
+            return;
+        }
+
+        var nextLocal = existing.LastPostedUtc.AddHours(existing.IntervalHours).ToLocalTime();
+        await RespondAsync($"チャンネル<#{existing.ChannelId}>で{existing.IntervalHours}時間ごとにメッセージを送信するよう設定されているよ！次の送信予定時刻は{nextLocal:yyyy/MM/dd HH:mm}だよ。");
+    }
+
+    [SlashCommand("overwrite-auto-message", "AIで会話を促す自動メッセージの設定を上書きします。")]
+    public async Task OverwriteAutoMessage(
+        [Summary("t", "メッセージを送信する間隔(時間)")] int t = 1,
+        [Summary("c", "メッセージを送信するチャンネル")] SocketTextChannel? channel = null,
+        [Summary("s", "最初のメッセージを送信する時刻 (HH:mm)")] string? startTime = null)
+    {
+        var channelId = channel?.Id ?? Context.Channel.Id;
+        var guildId = Context.Guild.Id;
+
+        var existing = _databaseService
+            .FindAll<AutoMessageChannel>(AutoMessageChannel.TableName)
+            .FirstOrDefault(x => x.GuildId == guildId);
+
+        if (existing is not null)
+        {
+            _databaseService.Delete(AutoMessageChannel.TableName, existing.Id);
+        }
+
+        DateTime lastPostedUtc;
+        string startMessage;
+
+        if (!string.IsNullOrWhiteSpace(startTime))
+        {
+            if (TimeSpan.TryParse(startTime, out var time))
+            {
+                var now = DateTime.Now;
+                var startLocal = new DateTime(now.Year, now.Month, now.Day, time.Hours, time.Minutes, 0);
+                if (startLocal <= now)
+                {
+                    startLocal = startLocal.AddDays(1);
+                }
+
+                var startUtc = startLocal.ToUniversalTime();
+                lastPostedUtc = startUtc.AddHours(-t);
+                startMessage = $"{startLocal:HH:mm}から";
+            }
+            else
+            {
+                await RespondAsync("開始時刻の形式が正しくないよ！（例: 09:00）");
+                return;
+            }
+        }
+        else
+        {
+            lastPostedUtc = DateTime.UtcNow;
+            startMessage = "今";
+        }
+
+        var data = new AutoMessageChannel
+        {
+            GuildId = guildId,
+            ChannelId = channelId,
+            IntervalHours = t,
+            LastPostedUtc = lastPostedUtc
+        };
+
+        _databaseService.Insert(AutoMessageChannel.TableName, data);
+
+        await RespondAsync($"チャンネル<#{channelId}>で{startMessage}{t}時間ごとにメッセージを送信するように上書き設定したよ！");
+    }
+
     [SlashCommand("remove-auto-message", "AIで会話を促す自動メッセージの設定を解除します。")]
     public async Task UnregisterAutoMessage()
     {


### PR DESCRIPTION
## Summary
- add `/show-auto-message` to display existing auto message configuration
- add `/overwrite-auto-message` to update auto message settings without manually removing

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689eff40a1bc832d9bfd2dc1ac963381