### PR TITLE
Add reminder command and background service

### DIFF
--- a/TsDiscordBot.Core/Commands/ReminderCommandModule.cs
+++ b/TsDiscordBot.Core/Commands/ReminderCommandModule.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Linq;
+using Discord.Interactions;
+using Discord.WebSocket;
+using Microsoft.Extensions.Logging;
+using TsDiscordBot.Core.Data;
+using TsDiscordBot.Core.Services;
+
+namespace TsDiscordBot.Core.Commands;
+
+public class ReminderCommandModule : InteractionModuleBase<SocketInteractionContext>
+{
+    private readonly ILogger _logger;
+    private readonly DatabaseService _databaseService;
+
+    public ReminderCommandModule(ILogger<ReminderCommandModule> logger, DatabaseService databaseService)
+    {
+        _logger = logger;
+        _databaseService = databaseService;
+    }
+
+    [SlashCommand("remind", "指定した時刻にリマインドを設定します。")]
+    public async Task RegisterReminder(
+        [Summary("time", "リマインドする時刻 (yyyy/MM/dd HH:mm)")] string time,
+        [Summary("message", "リマインド内容")] string message)
+    {
+        if (!DateTime.TryParse(time, out var localTime))
+        {
+            await RespondAsync("時刻の形式が正しくないよ！（例: 2024/01/01 09:00）");
+            return;
+        }
+
+        var data = new Reminder
+        {
+            GuildId = Context.Guild.Id,
+            ChannelId = Context.Channel.Id,
+            UserId = Context.User.Id,
+            RemindAtUtc = localTime.ToUniversalTime(),
+            Message = message
+        };
+
+        _databaseService.Insert(Reminder.TableName, data);
+
+        await RespondAsync($"{localTime:yyyy/MM/dd HH:mm}にリマインドするね！");
+    }
+
+    [SlashCommand("remind-remove", "あなたのリマインドを全て削除します。")]
+    public async Task RemoveReminder()
+    {
+        var guildId = Context.Guild.Id;
+        var userId = Context.User.Id;
+
+        var reminders = _databaseService
+            .FindAll<Reminder>(Reminder.TableName)
+            .Where(x => x.GuildId == guildId && x.UserId == userId)
+            .ToArray();
+
+        foreach (var reminder in reminders)
+        {
+            _databaseService.Delete(Reminder.TableName, reminder.Id);
+        }
+
+        await RespondAsync($"{reminders.Length}件のリマインドを削除したよ！");
+    }
+}

--- a/TsDiscordBot.Core/Data/Reminder.cs
+++ b/TsDiscordBot.Core/Data/Reminder.cs
@@ -1,0 +1,13 @@
+namespace TsDiscordBot.Core.Data;
+
+public class Reminder
+{
+    public const string TableName = "reminder";
+
+    public int Id { get; set; }
+    public ulong GuildId { get; set; }
+    public ulong ChannelId { get; set; }
+    public ulong UserId { get; set; }
+    public DateTime RemindAtUtc { get; set; }
+    public string Message { get; set; } = string.Empty;
+}

--- a/TsDiscordBot.Core/HostedService/ReminderService.cs
+++ b/TsDiscordBot.Core/HostedService/ReminderService.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Discord;
+using Discord.WebSocket;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using TsDiscordBot.Core.Data;
+using TsDiscordBot.Core.Services;
+
+namespace TsDiscordBot.Core.HostedService;
+
+public class ReminderService : BackgroundService
+{
+    private readonly DiscordSocketClient _client;
+    private readonly ILogger<ReminderService> _logger;
+    private readonly DatabaseService _databaseService;
+
+    public ReminderService(DiscordSocketClient client, ILogger<ReminderService> logger, DatabaseService databaseService)
+    {
+        _client = client;
+        _logger = logger;
+        _databaseService = databaseService;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                var reminders = _databaseService.FindAll<Reminder>(Reminder.TableName).ToArray();
+
+                foreach (var reminder in reminders)
+                {
+                    if (DateTime.UtcNow >= reminder.RemindAtUtc)
+                    {
+                        if (_client.GetChannel(reminder.ChannelId) is ISocketMessageChannel channel)
+                        {
+                            await channel.SendMessageAsync($"<@{reminder.UserId}> {reminder.Message}");
+                        }
+
+                        _databaseService.Delete(Reminder.TableName, reminder.Id);
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e, "Failed to process reminders");
+            }
+
+            await Task.Delay(TimeSpan.FromSeconds(30), stoppingToken);
+        }
+    }
+}

--- a/TsDiscordBot.Entry/Program.cs
+++ b/TsDiscordBot.Entry/Program.cs
@@ -41,6 +41,7 @@ using IHost host = Host.CreateDefaultBuilder(args)
         services.AddHostedService<NauAriService>();
         services.AddHostedService<TsumugiService>();
         services.AddHostedService<AutoMessageService>();
+        services.AddHostedService<ReminderService>();
     })
     .Build();
 


### PR DESCRIPTION
## Summary
- add `Reminder` data model
- implement `/remind` and `/remind-remove` commands
- add `ReminderService` to send scheduled notifications
- register reminder service in host configuration

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f00ea3a50832d83d0daec7bb35948