### PR TITLE
Handle empty show memories response

### DIFF
--- a/TsDiscordBot.Core/Commands/MemoryCommandModule.cs
+++ b/TsDiscordBot.Core/Commands/MemoryCommandModule.cs
@@ -79,6 +79,13 @@ public class MemoryCommandModule: InteractionModuleBase<SocketInteractionContext
             builder.AppendLine($"ID = {memory.Id}: {memory.Content} by {memory.Author}");
         }
 
-        await RespondAsync(builder.ToString());
+        if (builder.Length == 0)
+        {
+            await RespondAsync("何も覚えていないよ！");
+        }
+        else
+        {
+            await RespondAsync(builder.ToString());
+        }
     }
 }


### PR DESCRIPTION
## Summary
- prevent `/show-memories` from sending empty messages

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689f04ed5330832daa98098aee01691e