### PR TITLE
Fix timezone conversion in show-auto-message

### DIFF
--- a/TsDiscordBot.Core/Commands/AutoMessageCommandModule.cs
+++ b/TsDiscordBot.Core/Commands/AutoMessageCommandModule.cs
@@ -121,7 +121,13 @@ public class AutoMessageCommandModule: InteractionModuleBase<SocketInteractionCo
             jst = TimeZoneInfo.FindSystemTimeZoneById("Tokyo Standard Time");
         }
 
-        var nextLocal = TimeZoneInfo.ConvertTimeFromUtc(existing.LastPostedUtc.AddHours(existing.IntervalHours), jst);
+        var nextUtc = existing.LastPostedUtc;
+        if (nextUtc.Kind != DateTimeKind.Utc)
+        {
+            nextUtc = DateTime.SpecifyKind(nextUtc, DateTimeKind.Utc);
+        }
+
+        var nextLocal = TimeZoneInfo.ConvertTimeFromUtc(nextUtc.AddHours(existing.IntervalHours), jst);
         await RespondAsync($"チャンネル<#{existing.ChannelId}>で{existing.IntervalHours}時間ごとにメッセージを送信するよう設定されているよ！次の送信予定時刻は{nextLocal:yyyy/MM/dd HH:mm}だよ。");
     }
 


### PR DESCRIPTION
## Summary
- Ensure stored timestamps are treated as UTC before converting to JST in `/show-auto-message`

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 - could not install dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_689f05eabc58832dbaddc77488c33793