### PR TITLE
Persist poll messages and collect queued results

### DIFF
--- a/TsDiscordBot.Core/Commands/PollCommandModule.cs
+++ b/TsDiscordBot.Core/Commands/PollCommandModule.cs
@@ -1,10 +1,9 @@
 using System.Text;
-using System.Linq;
 using Discord;
 using Discord.Interactions;
 using Microsoft.Extensions.Logging;
-using TsDiscordBot.Core.Data;
 using TsDiscordBot.Core.Services;
+using Poll = TsDiscordBot.Core.Data.Poll;
 
 namespace TsDiscordBot.Core.Commands;
 

--- a/TsDiscordBot.Core/Commands/PollCommandModule.cs
+++ b/TsDiscordBot.Core/Commands/PollCommandModule.cs
@@ -3,16 +3,20 @@ using System.Linq;
 using Discord;
 using Discord.Interactions;
 using Microsoft.Extensions.Logging;
+using TsDiscordBot.Core.Data;
+using TsDiscordBot.Core.Services;
 
 namespace TsDiscordBot.Core.Commands;
 
 public class PollCommandModule : InteractionModuleBase<SocketInteractionContext>
 {
     private readonly ILogger _logger;
+    private readonly DatabaseService _databaseService;
 
-    public PollCommandModule(ILogger<PollCommandModule> logger)
+    public PollCommandModule(ILogger<PollCommandModule> logger, DatabaseService databaseService)
     {
         _logger = logger;
+        _databaseService = databaseService;
     }
 
     [SlashCommand("poll", "質問と選択肢を指定して投票を開始します。")]
@@ -44,32 +48,81 @@ public class PollCommandModule : InteractionModuleBase<SocketInteractionContext>
             await message.AddReactionAsync(new Emoji(emojis[i]));
         }
 
+        _databaseService.Insert(Poll.TableName, new Poll
+        {
+            ChannelId = Context.Channel.Id,
+            MessageId = message.Id
+        });
+
         await RespondAsync($"投票を開始しました。メッセージID: {message.Id}", ephemeral: true);
     }
 
-    [SlashCommand("poll-result", "メッセージIDから投票結果を集計します。")]
-    public async Task ShowPollResult(ulong messageId)
+    [SlashCommand("poll-result", "保存された投票の結果を集計します。")]
+    public async Task ShowPollResult([MinValue(1)] int order = 1)
     {
-        if (await Context.Channel.GetMessageAsync(messageId) is not IUserMessage message)
+        try
         {
-            await RespondAsync("指定したメッセージが見つかりません。", ephemeral: true);
-            return;
+            var polls = _databaseService.FindAll<Poll>(Poll.TableName)
+                .OrderBy(p => p.Id)
+                .ToList();
+
+            if (!polls.Any())
+            {
+                await RespondAsync("集計する投票がありません。", ephemeral: true);
+                return;
+            }
+
+            if (order < 1 || order > polls.Count)
+            {
+                await RespondAsync("指定した番号の投票が見つかりません。", ephemeral: true);
+                return;
+            }
+
+            int index = order - 1;
+
+            while (index < polls.Count)
+            {
+                var poll = polls[index];
+                var channel = await Context.Client.GetChannelAsync(poll.ChannelId) as IMessageChannel;
+
+                if (channel is null)
+                {
+                    _databaseService.Delete(Poll.TableName, poll.Id);
+                    polls.RemoveAt(index);
+                    continue;
+                }
+
+                if (await channel.GetMessageAsync(poll.MessageId) is not IUserMessage message)
+                {
+                    _databaseService.Delete(Poll.TableName, poll.Id);
+                    polls.RemoveAt(index);
+                    continue;
+                }
+
+                var emojis = new[] { "1️⃣", "2️⃣", "3️⃣", "4️⃣", "5️⃣" };
+                var lines = message.Content.Split('\n');
+                StringBuilder builder = new();
+                builder.AppendLine($"結果発表！！: {lines.FirstOrDefault()}");
+
+                for (int i = 1; i < lines.Length && i - 1 < emojis.Length; i++)
+                {
+                    var emoji = new Emoji(emojis[i - 1]);
+                    var count = message.Reactions.TryGetValue(emoji, out var reaction)
+                        ? reaction.ReactionCount - 1
+                        : 0;
+                    builder.AppendLine($"{lines[i]} : {count}");
+                }
+
+                await RespondAsync(builder.ToString());
+                _databaseService.Delete(Poll.TableName, poll.Id);
+                return;
+            }
+
+            await RespondAsync("集計する投票がありません。", ephemeral: true);
         }
-
-        var emojis = new[] { "1️⃣", "2️⃣", "3️⃣", "4️⃣", "5️⃣" };
-        var lines = message.Content.Split('\n');
-        StringBuilder builder = new();
-        builder.AppendLine($"結果発表！！: {lines.FirstOrDefault()}");
-
-        for (int i = 1; i < lines.Length && i - 1 < emojis.Length; i++)
+        catch (Exception e)
         {
-            var emoji = new Emoji(emojis[i - 1]);
-            var count = message.Reactions.TryGetValue(emoji, out var reaction)
-                ? reaction.ReactionCount - 1
-                : 0;
-            builder.AppendLine($"{lines[i]} : {count}");
+            _logger.LogError(e, "Failed to show poll result.");
         }
-
-        await RespondAsync(builder.ToString());
     }
 }

--- a/TsDiscordBot.Core/Data/Poll.cs
+++ b/TsDiscordBot.Core/Data/Poll.cs
@@ -1,0 +1,11 @@
+namespace TsDiscordBot.Core.Data;
+
+public class Poll
+{
+    public const string TableName = "poll";
+
+    public int Id { get; set; }
+    public ulong ChannelId { get; set; }
+    public ulong MessageId { get; set; }
+}
+


### PR DESCRIPTION
## Summary
- store poll message metadata in LiteDB so users don't need to remember message IDs
- add poll-result command that aggregates the earliest (or chosen) poll and removes it from the database

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689f06c83bc4832dba80ddd81754420a