### PR TITLE
Add image generation slash command

### DIFF
--- a/TsDiscordBot.Core/Commands/ImageCommandModule.cs
+++ b/TsDiscordBot.Core/Commands/ImageCommandModule.cs
@@ -26,7 +26,7 @@ public class ImageCommandModule : InteractionModuleBase<SocketInteractionContext
 
         try
         {
-            var results = await _imageService.GenerateAsync(description, 1, 1024);
+            var results = await _imageService.GenerateAsync(description, 1, 256);
             if (results.Count == 0)
             {
                 await FollowupAsync("画像生成に失敗しました。");

--- a/TsDiscordBot.Core/Commands/ImageCommandModule.cs
+++ b/TsDiscordBot.Core/Commands/ImageCommandModule.cs
@@ -1,0 +1,72 @@
+using System.IO;
+using System.Net.Http;
+using Discord.Interactions;
+using Microsoft.Extensions.Logging;
+using TsDiscordBot.Core.Services;
+using TsDiscordBot.Core;
+
+namespace TsDiscordBot.Core.Commands;
+
+public class ImageCommandModule : InteractionModuleBase<SocketInteractionContext>
+{
+    private readonly ILogger _logger;
+    private readonly IOpenAIImageService _imageService;
+
+    public ImageCommandModule(ILogger<ImageCommandModule> logger, IOpenAIImageService imageService)
+    {
+        _logger = logger;
+        _imageService = imageService;
+    }
+
+    [SlashCommand("image", "説明文から画像を生成します")]
+    public async Task GenerateImage(string description)
+    {
+        await DeferAsync();
+        await ModifyOriginalResponseAsync(msg => msg.Content = "生成中です...");
+
+        try
+        {
+            var results = await _imageService.GenerateAsync(description, 1, 1024);
+            if (results.Count == 0)
+            {
+                await FollowupAsync("画像生成に失敗しました。");
+                return;
+            }
+
+            var result = results[0];
+            byte[] imageBytes;
+
+            if (result.HasUri)
+            {
+                using var http = new HttpClient();
+                imageBytes = await http.GetByteArrayAsync(result.Uri);
+            }
+            else if (result.HasBytes)
+            {
+                imageBytes = result.Bytes!.Value.ToArray();
+            }
+            else
+            {
+                await FollowupAsync("画像生成に失敗しました。");
+                return;
+            }
+
+            var dir = Path.GetDirectoryName(Envs.LITEDB_PATH);
+            if (string.IsNullOrWhiteSpace(dir))
+            {
+                dir = ".";
+            }
+            Directory.CreateDirectory(dir);
+            var filePath = Path.Combine(dir, $"generated_{DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()}.png");
+            await File.WriteAllBytesAsync(filePath, imageBytes);
+
+            await FollowupWithFileAsync(filePath);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to generate image");
+            await FollowupAsync("画像生成中にエラーが発生しました。");
+        }
+    }
+}
+

--- a/TsDiscordBot.Entry/Program.cs
+++ b/TsDiscordBot.Entry/Program.cs
@@ -32,6 +32,14 @@ using IHost host = Host.CreateDefaultBuilder(args)
         });
         services.AddSingleton<DatabaseService>();
         services.AddSingleton<OpenAIService>();
+        services.AddSingleton<IOpenAIImageService>(_ =>
+        {
+            var opts = new OpenAIImageOptions
+            {
+                ApiKey = Envs.OPENAI_API_KEY,
+            };
+            return OpenAIImageService.Create(opts);
+        });
 
         // Add hosted services
         services.AddHostedService<InteractionHandlingService>();


### PR DESCRIPTION
## Summary
- add `/image` slash command to generate images through OpenAI
- store generated image next to LiteDB file and send as attachment
- register `IOpenAIImageService` for dependency injection

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a551428aac832d9d80c77bda44062c