### PR TITLE
Add detailed image command with persistent rate limiting

### DIFF
--- a/TsDiscordBot.Core/Commands/ImageCommandModule.cs
+++ b/TsDiscordBot.Core/Commands/ImageCommandModule.cs
@@ -81,8 +81,7 @@ public class ImageCommandModule : InteractionModuleBase<SocketInteractionContext
     [SlashCommand("image-detail", "詳細を指定して画像を生成します")]
     public async Task GenerateImageDetail(
         string description,
-        [MinValue(1), MaxValue(3)] int count = 1,
-        [Choice("256", 256), Choice("512", 512), Choice("1024", 1024)] int size = 256)
+        [MinValue(1), MaxValue(3)] int count = 1)
     {
         if (!_limitService.TryAdd(Context.User.Id, "image-detail", 1, TimeSpan.FromHours(8)))
         {
@@ -96,7 +95,7 @@ public class ImageCommandModule : InteractionModuleBase<SocketInteractionContext
         try
         {
             count = Math.Clamp(count, 1, 3);
-            var results = await _imageService.GenerateAsync(description, count, size);
+            var results = await _imageService.GenerateAsync(description, count, 1024);
             if (results.Count == 0)
             {
                 await FollowupAsync("画像生成に失敗しました。");

--- a/TsDiscordBot.Core/Commands/ImageCommandModule.cs
+++ b/TsDiscordBot.Core/Commands/ImageCommandModule.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using System.Net.Http;
+using Discord;
 using Discord.Interactions;
 using Microsoft.Extensions.Logging;
 using TsDiscordBot.Core.Services;
@@ -11,16 +12,24 @@ public class ImageCommandModule : InteractionModuleBase<SocketInteractionContext
 {
     private readonly ILogger _logger;
     private readonly IOpenAIImageService _imageService;
+    private readonly IUserCommandLimitService _limitService;
 
-    public ImageCommandModule(ILogger<ImageCommandModule> logger, IOpenAIImageService imageService)
+    public ImageCommandModule(ILogger<ImageCommandModule> logger, IOpenAIImageService imageService, IUserCommandLimitService limitService)
     {
         _logger = logger;
         _imageService = imageService;
+        _limitService = limitService;
     }
 
     [SlashCommand("image", "説明文から画像を生成します")]
     public async Task GenerateImage(string description)
     {
+        if (!_limitService.TryAdd(Context.User.Id, "image"))
+        {
+            await RespondAsync("このコマンドは1時間に3回まで利用できます。", ephemeral: true);
+            return;
+        }
+
         await DeferAsync();
         await ModifyOriginalResponseAsync(msg => msg.Content = "生成中です...");
 
@@ -61,6 +70,78 @@ public class ImageCommandModule : InteractionModuleBase<SocketInteractionContext
             await File.WriteAllBytesAsync(filePath, imageBytes);
 
             await FollowupWithFileAsync(filePath);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to generate image");
+            await FollowupAsync("画像生成中にエラーが発生しました。");
+        }
+    }
+
+    [SlashCommand("image-detail", "詳細を指定して画像を生成します")]
+    public async Task GenerateImageDetail(
+        string description,
+        [MinValue(1), MaxValue(3)] int count = 1,
+        [Choice("256", 256), Choice("512", 512), Choice("1024", 1024)] int size = 256)
+    {
+        if (!_limitService.TryAdd(Context.User.Id, "image-detail", 1, TimeSpan.FromHours(8)))
+        {
+            await RespondAsync("このコマンドは8時間に1回まで利用できます。", ephemeral: true);
+            return;
+        }
+
+        await DeferAsync();
+        await ModifyOriginalResponseAsync(msg => msg.Content = "生成中です...");
+
+        try
+        {
+            count = Math.Clamp(count, 1, 3);
+            var results = await _imageService.GenerateAsync(description, count, size);
+            if (results.Count == 0)
+            {
+                await FollowupAsync("画像生成に失敗しました。");
+                return;
+            }
+
+            var dir = Path.GetDirectoryName(Envs.LITEDB_PATH);
+            if (string.IsNullOrWhiteSpace(dir))
+            {
+                dir = ".";
+            }
+            Directory.CreateDirectory(dir);
+
+            var attachments = new List<FileAttachment>();
+            int index = 0;
+            foreach (var result in results)
+            {
+                byte[] imageBytes;
+                if (result.HasUri)
+                {
+                    using var http = new HttpClient();
+                    imageBytes = await http.GetByteArrayAsync(result.Uri);
+                }
+                else if (result.HasBytes)
+                {
+                    imageBytes = result.Bytes!.Value.ToArray();
+                }
+                else
+                {
+                    continue;
+                }
+
+                var filePath = Path.Combine(dir, $"generated_{DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()}_{index}.png");
+                await File.WriteAllBytesAsync(filePath, imageBytes);
+                attachments.Add(new FileAttachment(filePath));
+                index++;
+            }
+
+            if (attachments.Count == 0)
+            {
+                await FollowupAsync("画像生成に失敗しました。");
+                return;
+            }
+
+            await FollowupWithFilesAsync(attachments);
         }
         catch (Exception ex)
         {

--- a/TsDiscordBot.Core/Data/CommandUsage.cs
+++ b/TsDiscordBot.Core/Data/CommandUsage.cs
@@ -1,0 +1,11 @@
+namespace TsDiscordBot.Core.Data;
+
+public class CommandUsage
+{
+    public const string TableName = "command_usage";
+
+    public int Id { get; set; }
+    public ulong UserId { get; set; }
+    public string CommandName { get; set; } = string.Empty;
+    public DateTimeOffset UsedAt { get; set; }
+}

--- a/TsDiscordBot.Core/Services/UserCommandLimitService.cs
+++ b/TsDiscordBot.Core/Services/UserCommandLimitService.cs
@@ -1,0 +1,68 @@
+using Microsoft.Extensions.Logging;
+using TsDiscordBot.Core.Data;
+
+namespace TsDiscordBot.Core.Services;
+
+public interface IUserCommandLimitService
+{
+    /// <summary>
+    /// Try to register a command execution for a user. Returns false if the user has exceeded the limit.
+    /// </summary>
+    bool TryAdd(ulong userId, string commandName, int limit = 3, TimeSpan? interval = null);
+}
+
+public class UserCommandLimitService : IUserCommandLimitService
+{
+    private readonly DatabaseService _db;
+    private readonly ILogger _logger;
+    private static readonly TimeSpan DefaultInterval = TimeSpan.FromHours(1);
+    private const int DefaultLimit = 3;
+
+    public UserCommandLimitService(DatabaseService db, ILogger<UserCommandLimitService> logger)
+    {
+        _db = db;
+        _logger = logger;
+    }
+
+    public bool TryAdd(ulong userId, string commandName, int limit = DefaultLimit, TimeSpan? interval = null)
+    {
+        interval ??= DefaultInterval;
+
+        var now = DateTimeOffset.UtcNow;
+        var records = _db.FindAll<CommandUsage>(CommandUsage.TableName)
+            .Where(x => x.UserId == userId && x.CommandName == commandName)
+            .ToList();
+
+        foreach (var record in records)
+        {
+            if (now - record.UsedAt > interval)
+            {
+                _db.Delete(CommandUsage.TableName, record.Id);
+            }
+        }
+
+        var recent = records.Where(r => now - r.UsedAt <= interval).ToList();
+        if (recent.Count >= limit)
+        {
+            return false;
+        }
+
+        var usage = new CommandUsage
+        {
+            UserId = userId,
+            CommandName = commandName,
+            UsedAt = now,
+        };
+        try
+        {
+            _db.Insert(CommandUsage.TableName, usage);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Failed to insert command usage");
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/TsDiscordBot.Entry/Program.cs
+++ b/TsDiscordBot.Entry/Program.cs
@@ -32,6 +32,7 @@ using IHost host = Host.CreateDefaultBuilder(args)
         });
         services.AddSingleton<DatabaseService>();
         services.AddSingleton<OpenAIService>();
+        services.AddSingleton<IUserCommandLimitService, UserCommandLimitService>();
         services.AddSingleton<IOpenAIImageService>(_ =>
         {
             var opts = new OpenAIImageOptions


### PR DESCRIPTION
## Summary
- add `/image-detail` command to generate multiple images with selectable sizes
- persist command usage in LiteDB and enforce per-user rate limits
- limit `/image-detail` to once every 8 hours and `/image` to 3 times per hour

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a553d12160832d8371cefe0b692ac3