### PR TITLE
Allow !revise to edit images from any user

### DIFF
--- a/TsDiscordBot.Core/HostedService/ImageReviseService.cs
+++ b/TsDiscordBot.Core/HostedService/ImageReviseService.cs
@@ -96,7 +96,7 @@ namespace TsDiscordBot.Core.HostedService
                     return;
 
                 var referenced = await message.Channel.GetMessageAsync(message.Reference.MessageId.Value);
-                if (referenced is null || referenced.Author.Id != _client.CurrentUser.Id)
+                if (referenced is null)
                     return;
 
                 var attachment = referenced.Attachments.FirstOrDefault(a => a.ContentType?.StartsWith("image/") == true);


### PR DESCRIPTION
## Summary
- allow `!revise` command to edit images from any user's message

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68a57d7cb690832d8416c9eed0c452ff