### PR TITLE
Switch image generation to DALL-E 2 low resolution

### DIFF
--- a/TsDiscordBot.Core/Services/OpenAIImageService.cs
+++ b/TsDiscordBot.Core/Services/OpenAIImageService.cs
@@ -65,7 +65,7 @@ public sealed class OpenAIImageService : IOpenAIImageService
     public async Task<IReadOnlyList<GeneratedImageResult>> GenerateAsync(
         string prompt,
         int count = 1,
-        int size = 1024,
+        int size = 256,
         CancellationToken ct = default)
     {
         if (string.IsNullOrWhiteSpace(prompt))
@@ -78,7 +78,7 @@ public sealed class OpenAIImageService : IOpenAIImageService
             var response = await _client.GenerateImagesAsync(prompt, count,
                 new ImageGenerationOptions
                 {
-                    Quality = GeneratedImageQuality.Standard,
+                    Size = new GeneratedImageSize(size, size),
                 },
                 cancellationToken:ct).ConfigureAwait(false);
 

--- a/TsDiscordBot.Entry/Program.cs
+++ b/TsDiscordBot.Entry/Program.cs
@@ -38,6 +38,7 @@ using IHost host = Host.CreateDefaultBuilder(args)
             var opts = new OpenAIImageOptions
             {
                 ApiKey = Envs.OPENAI_API_KEY,
+                Model = "dall-e-2",
             };
             return OpenAIImageService.Create(opts);
         });


### PR DESCRIPTION
## Summary
- use DALL-E 2 image model instead of gpt-image-1
- generate images at low 256×256 resolution by default

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68a65fb0b208832dae0a6634820d4443