### PR TITLE
fix: replace unsupported image quality value

### DIFF
--- a/TsDiscordBot.Core/Services/OpenAIImageService.cs
+++ b/TsDiscordBot.Core/Services/OpenAIImageService.cs
@@ -78,7 +78,10 @@ public sealed class OpenAIImageService : IOpenAIImageService
             var response = await _client.GenerateImagesAsync(prompt, count,
                 new ImageGenerationOptions
                 {
-                    Quality = GeneratedImageQuality.Standard,
+                    // "Standard" is no longer supported; using low quality.
+#pragma warning disable OPENAI001
+                    Quality = GeneratedImageQuality.Low,
+#pragma warning restore OPENAI001
                 },
                 cancellationToken:ct).ConfigureAwait(false);
 

--- a/TsDiscordBot.Core/TsDiscordBot.Core.csproj
+++ b/TsDiscordBot.Core/TsDiscordBot.Core.csproj
@@ -14,7 +14,7 @@
         <PackageReference Include="LiteDB" Version="5.0.21" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
         <PackageReference Include="NetEscapades.Configuration.Yaml" Version="3.0.0" />
-        <PackageReference Include="OpenAI" Version="2.1.0" />
+        <PackageReference Include="OpenAI" Version="2.3.0" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- update image generation quality option to low
- upgrade OpenAI client to access latest quality values

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a94a24a2d8832da4f961918858529d