### PR TITLE
feat: improve openai error handling

### DIFF
--- a/TsDiscordBot.Core/Utility/OpenAIErrorHelper.cs
+++ b/TsDiscordBot.Core/Utility/OpenAIErrorHelper.cs
@@ -1,0 +1,38 @@
+using System.ClientModel;
+using System.IO;
+using System.Text.Json;
+
+namespace TsDiscordBot.Core.Utility;
+
+public static class OpenAIErrorHelper
+{
+    public static string? TryGetErrorCode(ClientResultException? ex)
+    {
+        if (ex is null)
+        {
+            return null;
+        }
+
+        try
+        {
+            var response = ex.GetRawResponse();
+            if (response?.ContentStream is Stream stream)
+            {
+                using var reader = new StreamReader(stream);
+                var body = reader.ReadToEnd();
+                using var doc = JsonDocument.Parse(body);
+                if (doc.RootElement.TryGetProperty("error", out var error) &&
+                    error.TryGetProperty("code", out var code))
+                {
+                    return code.GetString();
+                }
+            }
+        }
+        catch
+        {
+            // Ignore failures when parsing error response.
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary
- parse OpenAI error responses for code extraction
- show friendly messages when quota is exceeded or policy is violated
- decline sensitive image generation requests

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68aa733da420832d83f6650f7595f1eb