### PR TITLE
Add Lavalink music playback prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,17 @@ docker build -t discord-net-bot .
 docker run -e DISCORD_TOKEN=your_token -e OPENAI_API_KEY=your_key discord-net-bot
 ```
 
+### Docker Compose と Lavalink / With Docker Compose and Lavalink
+
+Lavalink サーバーを含む環境を立ち上げる場合は `docker-compose` を利用できます。
+
+```bash
+# ビルド & 実行 / Build & Run
+docker compose up --build
+```
+
+`lavalink` サービスがポート `2333` で起動し、ボットはそれに接続します。
+
 ## コードデザイン / Code Design
 - 機能の中核は `TsDiscordBot.Core` に集約し、実行エントリは `TsDiscordBot.Entry` プロジェクトでホストしています。
 - 設定や機能拡張を容易にするため、依存性注入とモジュラー構成を採用しています。

--- a/TsDiscordBot.Core/Commands/MusicCommandModule.cs
+++ b/TsDiscordBot.Core/Commands/MusicCommandModule.cs
@@ -1,0 +1,42 @@
+using Discord;
+using Discord.Interactions;
+using Lavalink4NET;
+using Lavalink4NET.Player;
+using Lavalink4NET.Rest;
+
+namespace TsDiscordBot.Core.Commands;
+
+public class MusicCommandModule : InteractionModuleBase<SocketInteractionContext>
+{
+    private readonly IAudioService _audioService;
+
+    public MusicCommandModule(IAudioService audioService)
+    {
+        _audioService = audioService;
+    }
+
+    [SlashCommand("play", "Play a track in your voice channel")]
+    public async Task PlayAsync(string query)
+    {
+        var user = Context.User as IGuildUser;
+        var voiceChannel = user?.VoiceChannel;
+        if (voiceChannel is null)
+        {
+            await RespondAsync("You must be connected to a voice channel.");
+            return;
+        }
+
+        var player = _audioService.GetPlayer<LavalinkPlayer>(Context.Guild.Id)
+            ?? await _audioService.JoinAsync<LavalinkPlayer>(Context.Guild.Id, voiceChannel.Id);
+
+        var track = await _audioService.GetTrackAsync(query, SearchMode.YouTube);
+        if (track is null)
+        {
+            await RespondAsync("Track not found.");
+            return;
+        }
+
+        await player.PlayAsync(track);
+        await RespondAsync($"Now playing: {track.Title}");
+    }
+}

--- a/TsDiscordBot.Core/HostedService/LavalinkHostedService.cs
+++ b/TsDiscordBot.Core/HostedService/LavalinkHostedService.cs
@@ -1,0 +1,32 @@
+using Discord.WebSocket;
+using Lavalink4NET;
+using Microsoft.Extensions.Hosting;
+
+namespace TsDiscordBot.Core.HostedService;
+
+public class LavalinkHostedService : IHostedService
+{
+    private readonly IAudioService _audioService;
+    private readonly DiscordSocketClient _client;
+
+    public LavalinkHostedService(IAudioService audioService, DiscordSocketClient client)
+    {
+        _audioService = audioService;
+        _client = client;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        _client.Ready += InitializeAsync;
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        _client.Ready -= InitializeAsync;
+        return Task.CompletedTask;
+    }
+
+    private Task InitializeAsync()
+        => _audioService.InitializeAsync();
+}

--- a/TsDiscordBot.Core/TsDiscordBot.Core.csproj
+++ b/TsDiscordBot.Core/TsDiscordBot.Core.csproj
@@ -15,6 +15,8 @@
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
         <PackageReference Include="NetEscapades.Configuration.Yaml" Version="3.0.0" />
         <PackageReference Include="OpenAI" Version="2.3.0" />
+        <PackageReference Include="Lavalink4NET" Version="3.0.1" />
+        <PackageReference Include="Lavalink4NET.Discord.NET" Version="3.0.1" />
     </ItemGroup>
 
 </Project>

--- a/TsDiscordBot.Entry/Program.cs
+++ b/TsDiscordBot.Entry/Program.cs
@@ -1,6 +1,8 @@
 ﻿using Discord;
 using Discord.Interactions;
 using Discord.WebSocket;
+using Lavalink4NET;
+using Lavalink4NET.Discord.NET;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -41,6 +43,18 @@ using IHost host = Host.CreateDefaultBuilder(args)
             };
             return OpenAIImageService.Create(opts);
         });
+        services.AddSingleton<IDiscordClientWrapper>(provider =>
+        {
+            var client = provider.GetRequiredService<DiscordSocketClient>();
+            return new DiscordClientWrapper(client);
+        });
+        services.AddSingleton<IAudioService, LavalinkNode>();
+        services.AddSingleton(new LavalinkNodeOptions
+        {
+            RestUri = new Uri("http://localhost:2333"),
+            WebSocketUri = new Uri("ws://localhost:2333"),
+            Password = "youshallnotpass",
+        });
 
         // Add hosted services
         services.AddHostedService<InteractionHandlingService>();
@@ -52,6 +66,7 @@ using IHost host = Host.CreateDefaultBuilder(args)
         services.AddHostedService<AutoMessageService>();
         services.AddHostedService<ReminderService>();
         services.AddHostedService<ImageReviseService>();
+        services.AddHostedService<LavalinkHostedService>();
     })
     .Build();
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3.8'
+services:
+  bot:
+    build: .
+    environment:
+      - DISCORD_TOKEN=${DISCORD_TOKEN}
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+    depends_on:
+      - lavalink
+  lavalink:
+    image: ghcr.io/lavalink-devs/lavalink:4
+    ports:
+      - "2333:2333"


### PR DESCRIPTION
## Summary
- add docker-compose configuration to run Lavalink server alongside bot
- document docker compose usage for Lavalink

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68aa73950fd4832dbf9cc4e5c8a49317