### PR TITLE
Centralize error message constants

### DIFF
--- a/TsDiscordBot.Core/Commands/BannedCommandModule.cs
+++ b/TsDiscordBot.Core/Commands/BannedCommandModule.cs
@@ -1,5 +1,6 @@
 ﻿using Discord.Interactions;
 using Microsoft.Extensions.Logging;
+using TsDiscordBot.Core.Constants;
 using TsDiscordBot.Core.Data;
 using TsDiscordBot.Core.HostedService;
 using TsDiscordBot.Core.Services;
@@ -35,7 +36,7 @@ public class BannedCommandModule : InteractionModuleBase<SocketInteractionContex
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to add banned word.");
-            await RespondAsync("⚠️ 禁止ワードの登録に失敗しました。");
+            await RespondAsync(ErrorMessages.BannedWordAddFailed);
         }
     }
 
@@ -61,7 +62,7 @@ public class BannedCommandModule : InteractionModuleBase<SocketInteractionContex
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to remove banned word.");
-            await RespondAsync("⚠️ 禁止ワードの削除に失敗しました。");
+            await RespondAsync(ErrorMessages.BannedWordRemoveFailed);
         }
     }
 }

--- a/TsDiscordBot.Core/Commands/ImageCommandModule.cs
+++ b/TsDiscordBot.Core/Commands/ImageCommandModule.cs
@@ -3,6 +3,7 @@ using System.Text;
 using Discord;
 using Discord.Interactions;
 using Microsoft.Extensions.Logging;
+using TsDiscordBot.Core.Constants;
 using TsDiscordBot.Core.Services;
 using TsDiscordBot.Core.Utility;
 using System.ClientModel;
@@ -72,7 +73,7 @@ public class ImageCommandModule : InteractionModuleBase<SocketInteractionContext
 
         if (!_limitService.TryAdd(Context.User.Id, "image"))
         {
-            await RespondAsync("このコマンドは1時間に3回まで利用できます。", ephemeral: true);
+            await RespondAsync(ErrorMessages.CommandLimitExceeded, ephemeral: true);
             return;
         }
 
@@ -91,7 +92,7 @@ public class ImageCommandModule : InteractionModuleBase<SocketInteractionContext
                     await cts.CancelAsync();
                     await progressTask;
                     await ModifyOriginalResponseAsync(msg => msg.Content = GetFailedMessage(description, (int)stopWatch.Elapsed.TotalSeconds));
-                    await FollowupAsync("参照ファイルは画像ではありません。", ephemeral: true);
+                    await FollowupAsync(ErrorMessages.ReferenceFileNotImage, ephemeral: true);
                     return;
                 }
 
@@ -151,11 +152,11 @@ public class ImageCommandModule : InteractionModuleBase<SocketInteractionContext
             var code = OpenAIErrorHelper.TryGetErrorCode(ex.InnerException as ClientResultException);
             if (code == "insufficient_quota")
             {
-                await ModifyOriginalResponseAsync(msg => msg.Content = "@tsunetama token を使いきったみたいだだからチャージしてね！");
+                await ModifyOriginalResponseAsync(msg => msg.Content = ErrorMessages.InsufficientQuota);
             }
             else if (code == "content_policy_violation")
             {
-                await ModifyOriginalResponseAsync(msg => msg.Content = "ごめんね、その画像は作成できないの。");
+                await ModifyOriginalResponseAsync(msg => msg.Content = ErrorMessages.ContentPolicyViolationImage);
             }
             else
             {
@@ -183,7 +184,7 @@ public class ImageCommandModule : InteractionModuleBase<SocketInteractionContext
 
         if (!_limitService.TryAdd(Context.User.Id, "image-detail", 1, TimeSpan.FromHours(8)))
         {
-            await RespondAsync("このコマンドは8時間に1回まで利用できます。", ephemeral: true);
+            await RespondAsync(ErrorMessages.CommandLimitExceededLong, ephemeral: true);
             return;
         }
 
@@ -241,7 +242,7 @@ public class ImageCommandModule : InteractionModuleBase<SocketInteractionContext
                 await cts.CancelAsync();
                 await progressTask;
                 await ModifyOriginalResponseAsync(msg => msg.Content = GetFailedMessage(description,(int)stopWatch.Elapsed.TotalSeconds));
-                await FollowupAsync("画像生成に失敗しました。");
+                await FollowupAsync(ErrorMessages.ImageGenerationFailed);
                 return;
             }
 
@@ -257,11 +258,11 @@ public class ImageCommandModule : InteractionModuleBase<SocketInteractionContext
             var code = OpenAIErrorHelper.TryGetErrorCode(ex.InnerException as ClientResultException);
             if (code == "insufficient_quota")
             {
-                await ModifyOriginalResponseAsync(msg => msg.Content = "@tsunetama token を使いきったみたいだだからチャージしてね！");
+                await ModifyOriginalResponseAsync(msg => msg.Content = ErrorMessages.InsufficientQuota);
             }
             else if (code == "content_policy_violation")
             {
-                await ModifyOriginalResponseAsync(msg => msg.Content = "ごめんね、その画像は作成できないの。");
+                await ModifyOriginalResponseAsync(msg => msg.Content = ErrorMessages.ContentPolicyViolationImage);
             }
             else
             {

--- a/TsDiscordBot.Core/Constants/ErrorMessages.cs
+++ b/TsDiscordBot.Core/Constants/ErrorMessages.cs
@@ -1,0 +1,14 @@
+namespace TsDiscordBot.Core.Constants;
+
+public static class ErrorMessages
+{
+    public const string CommandLimitExceeded = "このコマンドは1時間に3回まで利用できます。";
+    public const string CommandLimitExceededLong = "このコマンドは8時間に1回まで利用できます。";
+    public const string ReferenceFileNotImage = "参照ファイルは画像ではありません。";
+    public const string ImageGenerationFailed = "画像生成に失敗しました。";
+    public const string BannedWordAddFailed = "⚠️ 禁止ワードの登録に失敗しました。";
+    public const string BannedWordRemoveFailed = "⚠️ 禁止ワードの削除に失敗しました。";
+    public const string InsufficientQuota = "@tsunetama token を使いきったみたいだだからチャージしてね！";
+    public const string ContentPolicyViolationQuestion = "ごめんね、その質問には答えられないの。";
+    public const string ContentPolicyViolationImage = "ごめんね、その画像は作成できないの。";
+}

--- a/TsDiscordBot.Core/HostedService/ImageReviseService.cs
+++ b/TsDiscordBot.Core/HostedService/ImageReviseService.cs
@@ -8,6 +8,7 @@ using Discord.WebSocket;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using TsDiscordBot.Core;
+using TsDiscordBot.Core.Constants;
 using TsDiscordBot.Core.Services;
 
 namespace TsDiscordBot.Core.HostedService
@@ -105,7 +106,7 @@ namespace TsDiscordBot.Core.HostedService
 
                 if (!_limitService.TryAdd(message.Author.Id, "image"))
                 {
-                    await message.Channel.SendMessageAsync("このコマンドは1時間に3回まで利用できます。", messageReference: new MessageReference(message.Id));
+                    await message.Channel.SendMessageAsync(ErrorMessages.CommandLimitExceeded, messageReference: new MessageReference(message.Id));
                     return;
                 }
 

--- a/TsDiscordBot.Core/Services/OpenAIService.cs
+++ b/TsDiscordBot.Core/Services/OpenAIService.cs
@@ -3,6 +3,7 @@ using System.Text;
 using System.ClientModel;
 using Microsoft.Extensions.Configuration;
 using OpenAI.Chat;
+using TsDiscordBot.Core.Constants;
 using TsDiscordBot.Core.Data;
 using TsDiscordBot.Core.Utility;
 
@@ -104,9 +105,9 @@ namespace TsDiscordBot.Core.Services
                 var code = OpenAIErrorHelper.TryGetErrorCode(ex);
                 return code switch
                 {
-                    "insufficient_quota" => "@tsunetama token を使いきったみたいだだからチャージしてね！",
-                    "content_policy_violation" => "ごめんね、その質問には答えられないの。",
-                    _ => "ごめんね、その質問には答えられないの。"
+                    "insufficient_quota" => ErrorMessages.InsufficientQuota,
+                    "content_policy_violation" => ErrorMessages.ContentPolicyViolationQuestion,
+                    _ => ErrorMessages.ContentPolicyViolationQuestion
                 };
             }
         }


### PR DESCRIPTION
## Summary
- centralize error response text in new `ErrorMessages` class
- refactor modules to reference shared error constants

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68aa75add218832dae562ceb756f8480