### PR TITLE
Add oversea relay for cross-server conversations

### DIFF
--- a/TsDiscordBot.Core/Commands/OverseaCommandModule.cs
+++ b/TsDiscordBot.Core/Commands/OverseaCommandModule.cs
@@ -1,0 +1,107 @@
+using System.Linq;
+using Discord.Interactions;
+using Microsoft.Extensions.Logging;
+using TsDiscordBot.Core.Data;
+using TsDiscordBot.Core.Services;
+
+namespace TsDiscordBot.Core.Commands;
+
+public class OverseaCommandModule : InteractionModuleBase<SocketInteractionContext>
+{
+    private readonly ILogger _logger;
+    private readonly DatabaseService _databaseService;
+
+    public OverseaCommandModule(ILogger<OverseaCommandModule> logger, DatabaseService databaseService)
+    {
+        _logger = logger;
+        _databaseService = databaseService;
+    }
+
+    [SlashCommand("oversea-register", "当該チャンネルマルチサーバー用に登録します。")]
+    public async Task Register(int id)
+    {
+        var channelId = Context.Channel.Id;
+        var existing = _databaseService.FindAll<OverseaChannel>(OverseaChannel.TableName)
+            .FirstOrDefault(x => x.ChannelId == channelId);
+
+        if (existing is not null)
+        {
+            existing.OverseaId = id;
+            _databaseService.Update(OverseaChannel.TableName, existing);
+        }
+        else
+        {
+            _databaseService.Insert(OverseaChannel.TableName, new OverseaChannel
+            {
+                OverseaId = id,
+                ChannelId = channelId
+            });
+        }
+
+        await RespondAsync($"このチャンネルをマルチサーバー{id}に登録したよ！");
+    }
+
+    [SlashCommand("oversea-leave", "当該チャンネルに登録されているマルチサーバーを解除します。")]
+    public async Task Leave()
+    {
+        var channelId = Context.Channel.Id;
+        var existing = _databaseService.FindAll<OverseaChannel>(OverseaChannel.TableName)
+            .FirstOrDefault(x => x.ChannelId == channelId);
+
+        if (existing is null)
+        {
+            await RespondAsync("このチャンネルは登録されていないよ！");
+            return;
+        }
+
+        _databaseService.Delete(OverseaChannel.TableName, existing.Id);
+        await RespondAsync("このチャンネルの登録を解除したよ！");
+    }
+
+    [SlashCommand("oversea-enable-anonymous", "投稿者を匿名化します。")]
+    public async Task EnableAnonymous(ulong userId)
+    {
+        var existing = _databaseService.FindAll<OverseaUserSetting>(OverseaUserSetting.TableName)
+            .FirstOrDefault(x => x.UserId == userId);
+
+        if (existing is null)
+        {
+            _databaseService.Insert(OverseaUserSetting.TableName, new OverseaUserSetting
+            {
+                UserId = userId,
+                IsAnonymous = true
+            });
+        }
+        else
+        {
+            existing.IsAnonymous = true;
+            _databaseService.Update(OverseaUserSetting.TableName, existing);
+        }
+
+        await RespondAsync($"<@{userId}>を匿名化したよ！");
+    }
+
+    [SlashCommand("oversea-disable-anonymous", "投稿者の匿名化を解除します。")]
+    public async Task DisableAnonymous(ulong userId)
+    {
+        var existing = _databaseService.FindAll<OverseaUserSetting>(OverseaUserSetting.TableName)
+            .FirstOrDefault(x => x.UserId == userId);
+
+        if (existing is null)
+        {
+            _databaseService.Insert(OverseaUserSetting.TableName, new OverseaUserSetting
+            {
+                UserId = userId,
+                IsAnonymous = false
+            });
+        }
+        else
+        {
+            existing.IsAnonymous = false;
+            _databaseService.Update(OverseaUserSetting.TableName, existing);
+        }
+
+        await RespondAsync($"<@{userId}>の匿名化を解除したよ！");
+    }
+}
+

--- a/TsDiscordBot.Core/Commands/OverseaCommandModule.cs
+++ b/TsDiscordBot.Core/Commands/OverseaCommandModule.cs
@@ -45,20 +45,25 @@ public class OverseaCommandModule : InteractionModuleBase<SocketInteractionConte
     public async Task Leave()
     {
         var channelId = Context.Channel.Id;
-        var existing = _databaseService.FindAll<OverseaChannel>(OverseaChannel.TableName)
-            .FirstOrDefault(x => x.ChannelId == channelId);
+        var channels = _databaseService.FindAll<OverseaChannel>(OverseaChannel.TableName)
+            .Where(x => x.ChannelId == channelId)
+            .ToArray();
 
-        if (existing is null)
+        if (channels.Length is 0)
         {
             await RespondAsync("このチャンネルは登録されていないよ！");
             return;
         }
 
-        _databaseService.Delete(OverseaChannel.TableName, existing.Id);
+        foreach (var ch in channels)
+        {
+            _databaseService.Delete(OverseaChannel.TableName, ch.Id);
+        }
+
         await RespondAsync("このチャンネルの登録を解除したよ！");
     }
 
-    [SlashCommand("oversea-enable-anonymous", "投稿者を匿名化します。")]
+    [SlashCommand("oversea-enable-anonymous", "投稿者を匿名化します。(標準は匿名化されます)")]
     public async Task EnableAnonymous(ulong userId)
     {
         var existing = _databaseService.FindAll<OverseaUserSetting>(OverseaUserSetting.TableName)

--- a/TsDiscordBot.Core/Data/OverseaChannel.cs
+++ b/TsDiscordBot.Core/Data/OverseaChannel.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace TsDiscordBot.Core.Data;
+
+public class OverseaChannel
+{
+    public const string TableName = "oversea_channel";
+
+    public int Id { get; set; }
+    public int OverseaId { get; set; }
+    public ulong ChannelId { get; set; }
+}
+

--- a/TsDiscordBot.Core/Data/OverseaUserSetting.cs
+++ b/TsDiscordBot.Core/Data/OverseaUserSetting.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace TsDiscordBot.Core.Data;
+
+public class OverseaUserSetting
+{
+    public const string TableName = "oversea_user_setting";
+
+    public int Id { get; set; }
+    public ulong UserId { get; set; }
+    public bool IsAnonymous { get; set; }
+}
+

--- a/TsDiscordBot.Core/HostedService/OverseaRelayService.cs
+++ b/TsDiscordBot.Core/HostedService/OverseaRelayService.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using Discord;
 using Discord.WebSocket;
 using Discord.Webhook;
@@ -15,10 +14,10 @@ public class OverseaRelayService : IHostedService
     private readonly ILogger<OverseaRelayService> _logger;
     private readonly DatabaseService _databaseService;
 
-    private OverseaChannel[] _channelCache = Array.Empty<OverseaChannel>();
-    private OverseaUserSetting[] _userCache = Array.Empty<OverseaUserSetting>();
+    private OverseaChannel[] _channelCache = [];
+    private OverseaUserSetting[] _userCache = [];
     private DateTime _lastQueryTime = DateTime.MinValue;
-    private readonly TimeSpan _querySpan = TimeSpan.FromSeconds(5);
+    private readonly TimeSpan _querySpan = TimeSpan.FromSeconds(15);
 
     public OverseaRelayService(DiscordSocketClient client, ILogger<OverseaRelayService> logger, DatabaseService databaseService)
     {

--- a/TsDiscordBot.Core/HostedService/OverseaRelayService.cs
+++ b/TsDiscordBot.Core/HostedService/OverseaRelayService.cs
@@ -1,0 +1,121 @@
+using System.Linq;
+using Discord;
+using Discord.WebSocket;
+using Discord.Webhook;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using TsDiscordBot.Core.Data;
+using TsDiscordBot.Core.Services;
+
+namespace TsDiscordBot.Core.HostedService;
+
+public class OverseaRelayService : IHostedService
+{
+    private readonly DiscordSocketClient _client;
+    private readonly ILogger<OverseaRelayService> _logger;
+    private readonly DatabaseService _databaseService;
+
+    private OverseaChannel[] _channelCache = Array.Empty<OverseaChannel>();
+    private OverseaUserSetting[] _userCache = Array.Empty<OverseaUserSetting>();
+    private DateTime _lastQueryTime = DateTime.MinValue;
+    private readonly TimeSpan _querySpan = TimeSpan.FromSeconds(5);
+
+    public OverseaRelayService(DiscordSocketClient client, ILogger<OverseaRelayService> logger, DatabaseService databaseService)
+    {
+        _client = client;
+        _logger = logger;
+        _databaseService = databaseService;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        _client.MessageReceived += OnMessageReceivedAsync;
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        _client.MessageReceived -= OnMessageReceivedAsync;
+        return Task.CompletedTask;
+    }
+
+    private async Task OnMessageReceivedAsync(SocketMessage message)
+    {
+        try
+        {
+            if (message.Source != MessageSource.User || message.Channel is not SocketGuildChannel)
+            {
+                return;
+            }
+
+            if (DateTime.Now - _lastQueryTime > _querySpan)
+            {
+                _channelCache = _databaseService.FindAll<OverseaChannel>(OverseaChannel.TableName).ToArray();
+                _userCache = _databaseService.FindAll<OverseaUserSetting>(OverseaUserSetting.TableName).ToArray();
+                _lastQueryTime = DateTime.Now;
+            }
+
+            var current = _channelCache.FirstOrDefault(x => x.ChannelId == message.Channel.Id);
+            if (current is null)
+            {
+                return;
+            }
+
+            var targets = _channelCache
+                .Where(x => x.OverseaId == current.OverseaId && x.ChannelId != current.ChannelId)
+                .ToArray();
+
+            if (!targets.Any())
+            {
+                return;
+            }
+
+            bool anonymous = _userCache.FirstOrDefault(x => x.UserId == message.Author.Id)?.IsAnonymous ?? true;
+            string username;
+            string? avatarUrl = null;
+
+            if (anonymous)
+            {
+                string hash = (message.Author.Id % 10000).ToString("D4");
+                username = $"どこかのサバの誰かさん#{hash}";
+            }
+            else
+            {
+                username = message.Author.Username;
+                avatarUrl = message.Author.GetAvatarUrl() ?? message.Author.GetDefaultAvatarUrl();
+            }
+
+            string content = message.Content;
+            if (message.Attachments.Any())
+            {
+                var urls = string.Join("\n", message.Attachments.Select(a => a.Url));
+                content = string.IsNullOrWhiteSpace(content) ? urls : content + "\n" + urls;
+            }
+
+            foreach (var target in targets)
+            {
+                if (await _client.GetChannelAsync(target.ChannelId) is ITextChannel channel)
+                {
+                    var webhook = await channel.CreateWebhookAsync("oversea-relay");
+                    var client = new DiscordWebhookClient(webhook);
+                    try
+                    {
+                        await client.SendMessageAsync(content, username: username, avatarUrl: avatarUrl);
+                    }
+                    finally
+                    {
+                        await webhook.DeleteAsync();
+                        client.Dispose();
+                    }
+                }
+            }
+
+            await message.DeleteAsync();
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Failed to relay oversea message.");
+        }
+    }
+}
+

--- a/TsDiscordBot.Core/TsDiscordBot.Core.csproj
+++ b/TsDiscordBot.Core/TsDiscordBot.Core.csproj
@@ -11,6 +11,7 @@
     <ItemGroup>
         <PackageReference Include="Discord.Net" Version="3.17.0" />
         <PackageReference Include="Discord.Net.WebSocket" Version="3.17.0" />
+        <PackageReference Include="Discord.Net.Webhook" Version="3.17.0" />
         <PackageReference Include="LiteDB" Version="5.0.21" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
         <PackageReference Include="NetEscapades.Configuration.Yaml" Version="3.0.0" />

--- a/TsDiscordBot.Entry/Program.cs
+++ b/TsDiscordBot.Entry/Program.cs
@@ -70,6 +70,7 @@ using IHost host = Host.CreateDefaultBuilder(args)
         services.AddHostedService<AutoMessageService>();
         services.AddHostedService<ReminderService>();
         services.AddHostedService<ImageReviseService>();
+        services.AddHostedService<OverseaRelayService>();
     })
     .Build();
 


### PR DESCRIPTION
## Summary
- allow registering channels to oversea groups and toggle user anonymity via new slash commands
- relay messages across registered channels using webhooks and optional anonymous usernames
- wire up service and add webhook package dependency

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68b296b33554832d80db36fbbf642a36