### PR TITLE
feat: allow anonymous profile customization

### DIFF
--- a/TsDiscordBot.Core/Data/OverseaUserSetting.cs
+++ b/TsDiscordBot.Core/Data/OverseaUserSetting.cs
@@ -9,5 +9,7 @@ public class OverseaUserSetting
     public int Id { get; set; }
     public ulong UserId { get; set; }
     public bool IsAnonymous { get; set; }
+    public string? AnonymousName { get; set; }
+    public string? AnonymousAvatarUrl { get; set; }
 }
 

--- a/TsDiscordBot.Core/HostedService/OverseaRelayService.cs
+++ b/TsDiscordBot.Core/HostedService/OverseaRelayService.cs
@@ -69,14 +69,18 @@ public class OverseaRelayService : IHostedService
                 return;
             }
 
-            bool anonymous = _userCache.FirstOrDefault(x => x.UserId == message.Author.Id)?.IsAnonymous ?? true;
+            var userSetting = _userCache.FirstOrDefault(x => x.UserId == message.Author.Id);
+            bool anonymous = userSetting?.IsAnonymous ?? true;
             string username;
             string? avatarUrl = null;
 
             if (anonymous)
             {
                 string hash = (message.Author.Id % 10000).ToString("D4");
-                username = $"どこかのサバの誰かさん#{hash}";
+                username = string.IsNullOrEmpty(userSetting?.AnonymousName)
+                    ? $"どこかのサバの誰かさん#{hash}"
+                    : userSetting.AnonymousName!;
+                avatarUrl = userSetting?.AnonymousAvatarUrl;
             }
             else
             {


### PR DESCRIPTION
## Summary
- allow selecting a target user from dropdown for anonymous settings
- let anonymous users set a display name and avatar
- use custom anonymous profile when relaying messages

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68b29e625958832db462b14facdf67d5