### PR TITLE
fix: prefer guild avatar for oversea relay

### DIFF
--- a/TsDiscordBot.Core/HostedService/OverseaRelayService.cs
+++ b/TsDiscordBot.Core/HostedService/OverseaRelayService.cs
@@ -87,6 +87,7 @@ public class OverseaRelayService : IHostedService
                 username = message.Author.Username;
                 if (message.Author is SocketGuildUser guildUser)
                 {
+                    username = guildUser.Nickname ?? message.Author.GlobalName ?? message.Author.Username;
                     avatarUrl = guildUser.GetGuildAvatarUrl() ??
                                 guildUser.GetAvatarUrl() ??
                                 guildUser.GetDefaultAvatarUrl();

--- a/TsDiscordBot.Core/HostedService/OverseaRelayService.cs
+++ b/TsDiscordBot.Core/HostedService/OverseaRelayService.cs
@@ -85,7 +85,17 @@ public class OverseaRelayService : IHostedService
             else
             {
                 username = message.Author.Username;
-                avatarUrl = message.Author.GetAvatarUrl() ?? message.Author.GetDefaultAvatarUrl();
+                if (message.Author is SocketGuildUser guildUser)
+                {
+                    avatarUrl = guildUser.GetGuildAvatarUrl() ??
+                                guildUser.GetAvatarUrl() ??
+                                guildUser.GetDefaultAvatarUrl();
+                }
+                else
+                {
+                    avatarUrl = message.Author.GetAvatarUrl() ??
+                                message.Author.GetDefaultAvatarUrl();
+                }
             }
 
             string content = message.Content;


### PR DESCRIPTION
## Summary
- use guild-specific avatar when available for oversea relay

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b2a1861fbc832da407d52b0d715744