### PR TITLE
Add command to bulk-register banned words

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ It supports chat generation, automatic reactions, banned word detection, and sch
 - スラッシュコマンドによる操作 / Control via slash commands
 - 特定ワードへのリアクション設定 / Custom reactions triggered by keywords
 - 禁止 ワードの検知とメッセージ削除 / Detects banned words and deletes offending messages
+- 複数禁止ワードの一括登録 / Bulk-register multiple banned words
 - 会話を促す自動メッセージ投稿 / Posts prompts automatically to encourage conversation
 - AI を使った画像生成・編集 / Generate and edit images with AI
 - 投票機能（作成・集計） / Create polls and tally results

--- a/TsDiscordBot.Core/Commands/BannedCommandModule.cs
+++ b/TsDiscordBot.Core/Commands/BannedCommandModule.cs
@@ -40,6 +40,39 @@ public class BannedCommandModule : InteractionModuleBase<SocketInteractionContex
         }
     }
 
+    [SlashCommand("add-banned-words", "カンマまたは改行区切りで禁止ワードを登録します。")]
+    public async Task AddBannedWords(string words)
+    {
+        try
+        {
+            var guildId = Context.Guild.Id;
+
+            var wordList = words
+                .Split(new[] { ',', '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries)
+                .Select(x => x.Trim())
+                .Where(x => !string.IsNullOrWhiteSpace(x))
+                .Distinct()
+                .ToArray();
+
+            foreach (var w in wordList)
+            {
+                _databaseService.Insert(BannedTriggerWord.TableName, new BannedTriggerWord
+                {
+                    GuildId = guildId,
+                    Word = w
+                });
+            }
+
+            var joined = string.Join(", ", wordList.Select(x => $"`{x}`"));
+            await RespondAsync($"🚫 禁止ワードを登録しました: {joined}");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to add banned words.");
+            await RespondAsync(ErrorMessages.BannedWordAddFailed);
+        }
+    }
+
     [SlashCommand("remove-banned-word", "登録されている禁止ワードを削除します。")]
     public async Task RemoveBannedWord(string word)
     {


### PR DESCRIPTION
## Summary
- support bulk banned-word registration via `/add-banned-words`
- document bulk registration in README

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b2acd2ab9c832d83ee7afc19994b9d