### PR TITLE
feat: add anonymous character selector

### DIFF
--- a/TsDiscordBot.Core/Commands/AnonymousProfileAutocompleteHandler.cs
+++ b/TsDiscordBot.Core/Commands/AnonymousProfileAutocompleteHandler.cs
@@ -1,0 +1,19 @@
+using Discord;
+using Discord.Interactions;
+using TsDiscordBot.Core.Services;
+
+namespace TsDiscordBot.Core.Commands;
+
+public class AnonymousProfileAutocompleteHandler : AutocompleteHandler
+{
+    public override Task<AutocompletionResult> GenerateSuggestionsAsync(IInteractionContext context, IAutocompleteInteraction interaction, IParameterInfo parameter, IServiceProvider services)
+    {
+        var value = interaction.Data.Current.Value as string ?? string.Empty;
+        var results = AnonymousProfileProvider.GetProfiles()
+            .Where(p => p.Name.Contains(value))
+            .Take(25)
+            .Select(p => new AutocompleteResult(p.Name, p.Name));
+
+        return Task.FromResult(AutocompletionResult.FromSuccess(results));
+    }
+}

--- a/TsDiscordBot.Core/Commands/OverseaCommandModule.cs
+++ b/TsDiscordBot.Core/Commands/OverseaCommandModule.cs
@@ -190,6 +190,8 @@ public class OverseaCommandModule : InteractionModuleBase<SocketInteractionConte
     [SlashCommand("cc", "匿名キャラクターを選択します。")]
     public async Task ChooseCharacter([Autocomplete(typeof(AnonymousProfileAutocompleteHandler))] string name)
     {
+        var discriminator = AnonymousProfileProvider.GetDiscriminator(Context.User.Id);
+
         var profile = AnonymousProfileProvider.GetProfileByName(name);
         if (profile is null)
         {
@@ -208,7 +210,7 @@ public class OverseaCommandModule : InteractionModuleBase<SocketInteractionConte
             {
                 UserId = user.Id,
                 IsAnonymous = true,
-                AnonymousName = profile.Name,
+                AnonymousName = $"{profile.Name}#{discriminator}",
                 AnonymousAvatarUrl = profile.AvatarUrl
             });
         }
@@ -217,7 +219,7 @@ public class OverseaCommandModule : InteractionModuleBase<SocketInteractionConte
             foreach (var setting in settings)
             {
                 setting.IsAnonymous = true;
-                setting.AnonymousName = profile.Name;
+                setting.AnonymousName = $"{profile.Name}#{discriminator}";
                 setting.AnonymousAvatarUrl = profile.AvatarUrl;
                 _databaseService.Update(OverseaUserSetting.TableName, setting);
             }

--- a/TsDiscordBot.Core/Services/AnonymousProfileProvider.cs
+++ b/TsDiscordBot.Core/Services/AnonymousProfileProvider.cs
@@ -54,6 +54,13 @@ public static class AnonymousProfileProvider
         return Profiles[index % Profiles.Length];
     }
 
+    public static IEnumerable<AnonymousProfile> GetProfiles() => Profiles;
+
+    public static AnonymousProfile? GetProfileByName(string name)
+    {
+        return Profiles.FirstOrDefault(p => p.Name == name);
+    }
+
     public static string GetDiscriminator(ulong userId)
     {
         return (userId % 10000).ToString("D4");

--- a/TsDiscordBot.Core/TsDiscordBot.Core.csproj
+++ b/TsDiscordBot.Core/TsDiscordBot.Core.csproj
@@ -12,6 +12,7 @@
         <PackageReference Include="Discord.Net" Version="3.17.0" />
         <PackageReference Include="Discord.Net.WebSocket" Version="3.17.0" />
         <PackageReference Include="Discord.Net.Webhook" Version="3.17.0" />
+        <PackageReference Include="Discord.Net.Interactions" Version="3.17.0" />
         <PackageReference Include="LiteDB" Version="5.0.21" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
         <PackageReference Include="NetEscapades.Configuration.Yaml" Version="3.0.0" />


### PR DESCRIPTION
## Summary
- add `/cc` command to pick an anonymous oversea profile
- expose predefined anonymous profiles and search by name
- support autocomplete for choosing profiles

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b3035cf718832d92dcd81044138f05