### PR TITLE
fix: show all cc characters with no argument

### DIFF
--- a/TsDiscordBot.Core/Commands/OverseaCommandModule.cs
+++ b/TsDiscordBot.Core/Commands/OverseaCommandModule.cs
@@ -193,15 +193,18 @@ public class OverseaCommandModule : InteractionModuleBase<SocketInteractionConte
     {
         if (string.IsNullOrWhiteSpace(name))
         {
-            var options = AnonymousProfileProvider.GetProfiles()
-                .Select(p => new SelectMenuOptionBuilder()
-                    .WithLabel(p.Name)
-                    .WithValue(p.Name))
-                .Take(25)
-                .ToList();
+            var component = new ComponentBuilder();
 
-            var component = new ComponentBuilder()
-                .WithSelectMenu("cc_select", options, "キャラクターを選択してね");
+            foreach (var chunk in AnonymousProfileProvider.GetProfiles().Chunk(25))
+            {
+                var options = chunk
+                    .Select(p => new SelectMenuOptionBuilder()
+                        .WithLabel(p.Name)
+                        .WithValue(p.Name))
+                    .ToList();
+
+                component.WithSelectMenu("cc_select", options, "キャラクターを選択してね");
+            }
 
             await RespondAsync("キャラクターを選択してね", components: component.Build(), ephemeral: false);
         }


### PR DESCRIPTION
## Summary
- allow `/cc` without arguments to show all available characters

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b3ab567b90832d9b3fa0e91b163bac