### PR TITLE
Switch to polling-based auto-delete

### DIFF
--- a/TsDiscordBot.Core/Data/AutoDeleteChannel.cs
+++ b/TsDiscordBot.Core/Data/AutoDeleteChannel.cs
@@ -10,4 +10,6 @@ public class AutoDeleteChannel
     public ulong GuildId { get; set; }
     public ulong ChannelId { get; set; }
     public int DelayMinutes { get; set; }
+    public DateTime EnabledAtUtc { get; set; }
+    public ulong LastMessageId { get; set; }
 }


### PR DESCRIPTION
## Summary
- store auto-delete enable timestamp and last seen message id in DB
- poll channels for new messages and schedule deletions
- update auto-delete enable command to initialize tracking values

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b41b82e2d8832dbf4d7815b0244fad