### PR TITLE
Switch to polling-based auto-delete

### DIFF
--- a/TsDiscordBot.Core/Data/AutoDeleteChannel.cs
+++ b/TsDiscordBot.Core/Data/AutoDeleteChannel.cs
@@ -10,4 +10,6 @@ public class AutoDeleteChannel
     public ulong GuildId { get; set; }
     public ulong ChannelId { get; set; }
     public int DelayMinutes { get; set; }
+    public DateTime EnabledAtUtc { get; set; }
+    public ulong LastMessageId { get; set; }
 }

--- a/TsDiscordBot.Core/HostedService/AutoDeleteService.cs
+++ b/TsDiscordBot.Core/HostedService/AutoDeleteService.cs
@@ -17,62 +17,11 @@ public class AutoDeleteService : BackgroundService
     private readonly ILogger<AutoDeleteService> _logger;
     private readonly DatabaseService _databaseService;
 
-    private AutoDeleteChannel[] _cache = [];
-    private DateTime _lastFetchTime = DateTime.MinValue;
-    private readonly TimeSpan CacheDuration = TimeSpan.FromSeconds(30);
-
     public AutoDeleteService(DiscordSocketClient client, ILogger<AutoDeleteService> logger, DatabaseService databaseService)
     {
         _client = client;
         _logger = logger;
         _databaseService = databaseService;
-    }
-
-    public override Task StartAsync(CancellationToken cancellationToken)
-    {
-        _client.MessageReceived += OnMessageReceivedAsync;
-        return base.StartAsync(cancellationToken);
-    }
-
-    public override Task StopAsync(CancellationToken cancellationToken)
-    {
-        _client.MessageReceived -= OnMessageReceivedAsync;
-        return base.StopAsync(cancellationToken);
-    }
-
-    private Task OnMessageReceivedAsync(SocketMessage message)
-    {
-        try
-        {
-            if (message.Author.IsBot || message.Channel is not SocketGuildChannel)
-                return Task.CompletedTask;
-
-            if ((DateTime.UtcNow - _lastFetchTime) > CacheDuration)
-            {
-                var list = _databaseService.FindAll<AutoDeleteChannel>(AutoDeleteChannel.TableName);
-                _cache = list.ToArray();
-                _lastFetchTime = DateTime.UtcNow;
-            }
-
-            var config = _cache.FirstOrDefault(x => x.ChannelId == message.Channel.Id);
-            if (config is null)
-                return Task.CompletedTask;
-
-            var data = new AutoDeleteMessage
-            {
-                ChannelId = message.Channel.Id,
-                MessageId = message.Id,
-                DeleteAtUtc = DateTime.UtcNow.AddMinutes(config.DelayMinutes)
-            };
-
-            _databaseService.Insert(AutoDeleteMessage.TableName, data);
-        }
-        catch (Exception e)
-        {
-            _logger.LogError(e, "Failed to handle message for auto delete");
-        }
-
-        return Task.CompletedTask;
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -81,6 +30,46 @@ public class AutoDeleteService : BackgroundService
         {
             try
             {
+                var configs = _databaseService.FindAll<AutoDeleteChannel>(AutoDeleteChannel.TableName).ToArray();
+
+                foreach (var config in configs)
+                {
+                    if (config.EnabledAtUtc == default || config.LastMessageId == default)
+                    {
+                        var now = DateTime.UtcNow;
+                        config.EnabledAtUtc = now;
+                        config.LastMessageId = SnowflakeUtils.ToSnowflake(now);
+                        _databaseService.Update(AutoDeleteChannel.TableName, config);
+                    }
+
+                    if (_client.GetChannel(config.ChannelId) is ITextChannel channel)
+                    {
+                        var messages = await channel.GetMessagesAsync(config.LastMessageId, Direction.After, 100).FlattenAsync();
+                        var targets = messages
+                            .Where(x => !x.Author.IsBot && !x.IsPinned)
+                            .OrderBy(x => x.Id)
+                            .ToArray();
+
+                        if (targets.Length > 0)
+                        {
+                            foreach (var msg in targets)
+                            {
+                                var data = new AutoDeleteMessage
+                                {
+                                    ChannelId = config.ChannelId,
+                                    MessageId = msg.Id,
+                                    DeleteAtUtc = msg.Timestamp.UtcDateTime.AddMinutes(config.DelayMinutes)
+                                };
+
+                                _databaseService.Insert(AutoDeleteMessage.TableName, data);
+                            }
+
+                            config.LastMessageId = targets.Last().Id;
+                            _databaseService.Update(AutoDeleteChannel.TableName, config);
+                        }
+                    }
+                }
+
                 var entries = _databaseService.FindAll<AutoDeleteMessage>(AutoDeleteMessage.TableName).ToArray();
 
                 foreach (var entry in entries.Where(x => DateTime.UtcNow >= DateTime.SpecifyKind(x.DeleteAtUtc, DateTimeKind.Utc)))


### PR DESCRIPTION
## Summary
- store auto-delete enable timestamp and last seen message id in DB
- poll channels for new messages and schedule deletions
- update auto-delete enable command to initialize tracking values
- initialize missing tracking fields to current time for legacy configs

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b41b82e2d8832dbf4d7815b0244fad