### PR TITLE
fix: avoid duplicate select menu IDs

### DIFF
--- a/TsDiscordBot.Core/Commands/OverseaCommandModule.cs
+++ b/TsDiscordBot.Core/Commands/OverseaCommandModule.cs
@@ -204,19 +204,20 @@ public class OverseaCommandModule : InteractionModuleBase<SocketInteractionConte
                         .WithValue(p.Name))
                     .ToList();
 
-                component.WithSelectMenu("cc_select", options, $"キャラクターを選択してね[{index++}]");
+                component.WithSelectMenu($"cc_select:{index}", options, $"キャラクターを選択してね[{index}]");
+                index++;
             }
 
             await RespondAsync("キャラクターを選択してね", components: component.Build(), ephemeral: false);
         }
         else
         {
-            await ChooseCharacterHandler(new[] { name });
+            await ChooseCharacterHandler(new[] { name }, 0);
         }
     }
 
-    [ComponentInteraction("cc_select")]
-    public async Task ChooseCharacterHandler(string[] selected)
+    [ComponentInteraction("cc_select:*")]
+    public async Task ChooseCharacterHandler(string[] selected, int _)
     {
         var name = selected.FirstOrDefault();
         if (string.IsNullOrWhiteSpace(name))


### PR DESCRIPTION
## Summary
- ensure each `/cc` select menu gets a unique custom ID
- handle `cc_select` interactions with wildcard pattern

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b42f1cf94c832d978ccadce1ae6def