### PR TITLE
feat: allow configurable banned text handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ It supports chat generation, automatic reactions, banned word detection, and sch
 - OpenAI を用いた対話機能 / OpenAI-based conversational replies
 - スラッシュコマンドによる操作 / Control via slash commands
 - 特定ワードへのリアクション設定 / Custom reactions triggered by keywords
-- 禁止 ワードの検知とメッセージ削除 / Detects banned words and deletes offending messages
+- 禁止 ワードの検知と伏字または削除 / Detects banned words and hides or deletes offending messages
 - 複数禁止ワードの一括登録 / Bulk-register multiple banned words
+- 禁止テキストモードの設定 (/set-banned-text-mode hide|delete)
 - 一定時間後にメッセージを自動削除 / Automatically delete messages after a set time
 - 会話を促す自動メッセージ投稿 / Posts prompts automatically to encourage conversation
 - AI を使った画像生成・編集 / Generate and edit images with AI

--- a/TsDiscordBot.Core/Data/BannedTextSetting.cs
+++ b/TsDiscordBot.Core/Data/BannedTextSetting.cs
@@ -1,0 +1,16 @@
+namespace TsDiscordBot.Core.Data
+{
+    public class BannedTextSetting
+    {
+        public const string TableName = "BannedTextSettings";
+        public int Id { get; set; }
+        public ulong GuildId { get; set; }
+        public BannedTextMode Mode { get; set; } = BannedTextMode.Hide;
+    }
+
+    public enum BannedTextMode
+    {
+        Hide,
+        Delete
+    }
+}

--- a/TsDiscordBot.Core/HostedService/BannedMessageCheckerService.cs
+++ b/TsDiscordBot.Core/HostedService/BannedMessageCheckerService.cs
@@ -1,6 +1,8 @@
 ﻿using Discord.WebSocket;
+using Discord;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using System.Text.RegularExpressions;
 using TsDiscordBot.Core.Data;
 using TsDiscordBot.Core.Services;
 
@@ -13,6 +15,7 @@ namespace TsDiscordBot.Core.HostedService
         private readonly DatabaseService _databaseService;
 
         private BannedTriggerWord[] _cache = [];
+        private BannedTextSetting[] _modeCache = [];
         private DateTime _lastFetchTime = DateTime.MinValue;
         private readonly TimeSpan CacheDuration = TimeSpan.FromSeconds(10);
 
@@ -52,8 +55,8 @@ namespace TsDiscordBot.Core.HostedService
 
                 if ((DateTime.Now - _lastFetchTime) > CacheDuration)
                 {
-                    var list = _databaseService.FindAll<BannedTriggerWord>(BannedTriggerWord.TableName);
-                    _cache = list.ToArray();
+                    _cache = _databaseService.FindAll<BannedTriggerWord>(BannedTriggerWord.TableName).ToArray();
+                    _modeCache = _databaseService.FindAll<BannedTextSetting>(BannedTextSetting.TableName).ToArray();
                     _lastFetchTime = DateTime.Now;
                 }
 
@@ -65,17 +68,51 @@ namespace TsDiscordBot.Core.HostedService
                 {
                     if (message.Content.Contains(keyword.Word, StringComparison.OrdinalIgnoreCase))
                     {
-                        await message.DeleteAsync();
-                        _logger.LogInformation($"Deleted banned message from {message.Author.Username}: {keyword.Word}");
+                        var mode = _modeCache.FirstOrDefault(x => x.GuildId == guildId)?.Mode ?? BannedTextMode.Hide;
 
-                        try
+                        if (mode == BannedTextMode.Delete)
                         {
-                            await message.Channel.SendMessageAsync(
-                                $"🔞 {message.Author.Mention} さん、不適切な発言が検出されたためメッセージを削除しました。");
+                            await message.DeleteAsync();
+                            _logger.LogInformation($"Deleted banned message from {message.Author.Username}: {keyword.Word}");
+
+                            try
+                            {
+                                await message.Channel.SendMessageAsync(
+                                    $"🔞 {message.Author.Mention} さん、不適切な発言が検出されたためメッセージを削除しました。");
+                            }
+                            catch (Exception dmEx)
+                            {
+                                _logger.LogWarning(dmEx, "Failed to send DM to user");
+                            }
                         }
-                        catch (Exception dmEx)
+                        else
                         {
-                            _logger.LogWarning(dmEx, "Failed to send DM to user");
+                            var sanitized = message.Content;
+                            foreach (var k in keywords)
+                            {
+                                sanitized = Regex.Replace(sanitized, Regex.Escape(k.Word), new string('＊', k.Word.Length), RegexOptions.IgnoreCase);
+                            }
+
+                            try
+                            {
+                                if (message is IUserMessage userMessage)
+                                {
+                                    await userMessage.ModifyAsync(m => m.Content = sanitized);
+                                }
+                                else
+                                {
+                                    await message.DeleteAsync();
+                                    await message.Channel.SendMessageAsync($"{message.Author.Mention}: {sanitized}");
+                                }
+                            }
+                            catch (Exception ex)
+                            {
+                                _logger.LogWarning(ex, "Failed to modify message, sending sanitized copy instead.");
+                                await message.DeleteAsync();
+                                await message.Channel.SendMessageAsync($"{message.Author.Mention}: {sanitized}");
+                            }
+
+                            _logger.LogInformation($"Masked banned message from {message.Author.Username}: {keyword.Word}");
                         }
 
                         break; // 1件でもヒットしたら処理終了（重複削除防止）


### PR DESCRIPTION
## Summary
- allow masking or deleting banned messages, default to masking with ＊
- add `/set-banned-text-mode` command to configure handling per guild
- document new banned text modes and command

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b96ea77b10832db60815556a7b2111