### PR TITLE
Detect banned words in message edits

### DIFF
--- a/TsDiscordBot.Core/HostedService/BannedMessageCheckerService.cs
+++ b/TsDiscordBot.Core/HostedService/BannedMessageCheckerService.cs
@@ -1,4 +1,5 @@
-﻿using Discord.WebSocket;
+﻿using Discord;
+using Discord.WebSocket;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using TsDiscordBot.Core.Data;
@@ -29,23 +30,35 @@ namespace TsDiscordBot.Core.HostedService
         public Task StartAsync(CancellationToken cancellationToken)
         {
             _client.MessageReceived += OnMessageReceivedAsync;
+            _client.MessageUpdated += OnMessageUpdatedAsync;
             return Task.CompletedTask;
         }
 
         public Task StopAsync(CancellationToken cancellationToken)
         {
             _client.MessageReceived -= OnMessageReceivedAsync;
+            _client.MessageUpdated -= OnMessageUpdatedAsync;
             return Task.CompletedTask;
         }
 
-        private async Task OnMessageReceivedAsync(SocketMessage message)
+        private Task OnMessageReceivedAsync(SocketMessage message) => CheckMessageAsync(message);
+
+        private Task OnMessageUpdatedAsync(Cacheable<IMessage, ulong> before, SocketMessage after, ISocketMessageChannel channel)
+        {
+            if (after is null)
+                return Task.CompletedTask;
+
+            return CheckMessageAsync(after);
+        }
+
+        private async Task CheckMessageAsync(SocketMessage message)
         {
             try
             {
                 if (message.Author.IsBot || message.Channel is not SocketGuildChannel guildChannel)
                     return;
 
-                if(message.Channel.Name.Contains("閲覧注意"))
+                if (message.Channel.Name.Contains("閲覧注意"))
                     return;
 
                 var guildId = guildChannel.Guild.Id;


### PR DESCRIPTION
## Summary
- check edited messages for banned words by handling `MessageUpdated`
- refactor banned message logic into reusable `CheckMessageAsync`

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b96f6cd118832db0f9a46794bd3363