### PR TITLE
Add unit test for Discord bot startup

### DIFF
--- a/TsDiscordBot.Core/HostedService/DiscordSocketClientAdapter.cs
+++ b/TsDiscordBot.Core/HostedService/DiscordSocketClientAdapter.cs
@@ -1,0 +1,32 @@
+using Discord;
+using Discord.WebSocket;
+
+namespace TsDiscordBot.Core.HostedService;
+
+public class DiscordSocketClientAdapter : IDiscordBotClient
+{
+    private readonly DiscordSocketClient _client;
+
+    public DiscordSocketClientAdapter(DiscordSocketClient client)
+    {
+        _client = client;
+    }
+
+    public event Func<LogMessage, Task>? Log
+    {
+        add { _client.Log += value; }
+        remove { _client.Log -= value; }
+    }
+
+    public Task LoginAsync(TokenType tokenType, string token)
+        => _client.LoginAsync(tokenType, token);
+
+    public Task StartAsync()
+        => _client.StartAsync();
+
+    public Task LogoutAsync()
+        => _client.LogoutAsync();
+
+    public Task StopAsync()
+        => _client.StopAsync();
+}

--- a/TsDiscordBot.Core/HostedService/DiscordStartupService.cs
+++ b/TsDiscordBot.Core/HostedService/DiscordStartupService.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Discord;
-using Discord.WebSocket;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -10,10 +9,10 @@ namespace TsDiscordBot.Core.HostedService;
 
 public class DiscordStartupService : IHostedService
 {
-    private readonly DiscordSocketClient _discord;
+    private readonly IDiscordBotClient _discord;
     private readonly IConfiguration _config;
 
-    public DiscordStartupService(DiscordSocketClient discord, IConfiguration config, ILogger<DiscordSocketClient> logger)
+    public DiscordStartupService(IDiscordBotClient discord, IConfiguration config, ILogger<IDiscordBotClient> logger)
     {
         _discord = discord;
         _config = config;
@@ -29,7 +28,7 @@ public class DiscordStartupService : IHostedService
             token = _config["token"];
         }
 
-        await _discord.LoginAsync(TokenType.Bot, token);
+        await _discord.LoginAsync(TokenType.Bot, token!);
         await _discord.StartAsync();
     }
 

--- a/TsDiscordBot.Core/HostedService/IDiscordBotClient.cs
+++ b/TsDiscordBot.Core/HostedService/IDiscordBotClient.cs
@@ -1,0 +1,12 @@
+using Discord;
+
+namespace TsDiscordBot.Core.HostedService;
+
+public interface IDiscordBotClient
+{
+    event Func<LogMessage, Task>? Log;
+    Task LoginAsync(TokenType tokenType, string token);
+    Task StartAsync();
+    Task LogoutAsync();
+    Task StopAsync();
+}

--- a/TsDiscordBot.Entry/Program.cs
+++ b/TsDiscordBot.Entry/Program.cs
@@ -25,6 +25,7 @@ using IHost host = Host.CreateDefaultBuilder(args)
             AlwaysDownloadUsers = true,
             MessageCacheSize = 100,
         }));
+        services.AddSingleton<IDiscordBotClient>(provider => new DiscordSocketClientAdapter(provider.GetRequiredService<DiscordSocketClient>()));
         services.AddSingleton<InteractionService>(provider =>
         {
             var client = provider.GetRequiredService<DiscordSocketClient>();

--- a/TsDiscordBot.Tests/DiscordStartupServiceTests.cs
+++ b/TsDiscordBot.Tests/DiscordStartupServiceTests.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Discord;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using TsDiscordBot.Core.HostedService;
+using Xunit;
+
+#nullable enable
+
+namespace TsDiscordBot.Tests;
+
+public class DiscordStartupServiceTests
+{
+    private class TestDiscordClient : IDiscordBotClient
+    {
+        public event Func<LogMessage, Task>? Log;
+        public TokenType? LoginTokenType { get; private set; }
+        public string? LoginToken { get; private set; }
+        public bool Started { get; private set; }
+        public bool LoggedOut { get; private set; }
+        public bool Stopped { get; private set; }
+
+        public Task LoginAsync(TokenType tokenType, string token)
+        {
+            LoginTokenType = tokenType;
+            LoginToken = token;
+            return Task.CompletedTask;
+        }
+
+        public Task StartAsync()
+        {
+            Started = true;
+            return Task.CompletedTask;
+        }
+
+        public Task LogoutAsync()
+        {
+            LoggedOut = true;
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync()
+        {
+            Stopped = true;
+            return Task.CompletedTask;
+        }
+    }
+
+    [Fact]
+    public async Task StartAsync_LogsInAndStartsClient()
+    {
+        var client = new TestDiscordClient();
+        Environment.SetEnvironmentVariable("DISCORD_TOKEN", "abc123");
+        var config = new ConfigurationBuilder().Build();
+        var service = new DiscordStartupService(client, config, NullLogger<IDiscordBotClient>.Instance);
+
+        await service.StartAsync(CancellationToken.None);
+
+        Assert.Equal(TokenType.Bot, client.LoginTokenType);
+        Assert.Equal("abc123", client.LoginToken);
+        Assert.True(client.Started);
+    }
+
+    [Fact]
+    public async Task StopAsync_LogsOutAndStopsClient()
+    {
+        var client = new TestDiscordClient();
+        var config = new ConfigurationBuilder().Build();
+        var service = new DiscordStartupService(client, config, NullLogger<IDiscordBotClient>.Instance);
+
+        await service.StopAsync(CancellationToken.None);
+
+        Assert.True(client.LoggedOut);
+        Assert.True(client.Stopped);
+    }
+}


### PR DESCRIPTION
## Summary
- add IDiscordBotClient abstraction and adapter for DiscordSocketClient
- wire up abstraction in startup service and DI container
- ensure bot login and start/stop are covered by new unit tests

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b97093208c832d98d3855ec6ffd415