### PR TITLE
feat: add server-wide anonymous profile

### DIFF
--- a/TsDiscordBot.Core/Commands/AnonymousCommandModule.cs
+++ b/TsDiscordBot.Core/Commands/AnonymousCommandModule.cs
@@ -1,0 +1,120 @@
+using Discord;
+using Discord.Interactions;
+using TsDiscordBot.Core.Data;
+using TsDiscordBot.Core.Services;
+
+namespace TsDiscordBot.Core.Commands;
+
+public class AnonymousCommandModule : InteractionModuleBase<SocketInteractionContext>
+{
+    private readonly DatabaseService _databaseService;
+
+    public AnonymousCommandModule(DatabaseService databaseService)
+    {
+        _databaseService = databaseService;
+    }
+
+    [SlashCommand("who", "サーバー全体で匿名化するキャラクターを選択します。")]
+    public async Task Who()
+    {
+        var options = AnonymousProfileProvider.GetProfiles()
+            .Select(p => new SelectMenuOptionBuilder()
+                .WithLabel(p.Name)
+                .WithValue(p.Name))
+            .Take(25)
+            .ToList();
+
+        var component = new ComponentBuilder()
+            .WithSelectMenu("who_select", options, "キャラクターを選択してね");
+
+        await RespondAsync("キャラクターを選択してね", components: component.Build(), ephemeral: true);
+    }
+
+    [ComponentInteraction("who_select")]
+    public async Task WhoSelectHandler(string[] selected)
+    {
+        var name = selected.FirstOrDefault();
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            await RespondAsync("指定されたキャラクターは見つからなかったよ！", ephemeral: true);
+            return;
+        }
+
+        var profile = AnonymousProfileProvider.GetProfileByName(name);
+        if (profile is null)
+        {
+            await RespondAsync("指定されたキャラクターは見つからなかったよ！", ephemeral: true);
+            return;
+        }
+
+        var user = Context.User;
+        var guildId = (Context.Guild?.Id) ?? 0;
+        var settings = _databaseService.FindAll<AnonymousGuildUserSetting>(AnonymousGuildUserSetting.TableName)
+            .Where(x => x.GuildId == guildId && x.UserId == user.Id)
+            .ToArray();
+
+        if (settings.Length is 0)
+        {
+            _databaseService.Insert(AnonymousGuildUserSetting.TableName, new AnonymousGuildUserSetting
+            {
+                GuildId = guildId,
+                UserId = user.Id,
+                IsAnonymous = true,
+                AnonymousName = profile.Name,
+                AnonymousAvatarUrl = profile.AvatarUrl
+            });
+        }
+        else
+        {
+            foreach (var setting in settings)
+            {
+                setting.IsAnonymous = true;
+                setting.AnonymousName = profile.Name;
+                setting.AnonymousAvatarUrl = profile.AvatarUrl;
+                _databaseService.Update(AnonymousGuildUserSetting.TableName, setting);
+            }
+        }
+
+        var embed = new EmbedBuilder()
+            .WithTitle("設定されたキャラクター")
+            .WithDescription($"{profile.Name}として表示されます。")
+            .WithImageUrl(profile.AvatarUrl)
+            .WithColor(Color.Blue)
+            .Build();
+
+        await RespondAsync("匿名キャラクターを設定したよ！", embed: embed, ephemeral: true);
+    }
+
+    [SlashCommand("iam", "サーバー全体の匿名化を解除します。")]
+    public async Task IAm()
+    {
+        var user = Context.User;
+        var guildId = (Context.Guild?.Id) ?? 0;
+        var settings = _databaseService.FindAll<AnonymousGuildUserSetting>(AnonymousGuildUserSetting.TableName)
+            .Where(x => x.GuildId == guildId && x.UserId == user.Id)
+            .ToArray();
+
+        if (settings.Length is 0)
+        {
+            _databaseService.Insert(AnonymousGuildUserSetting.TableName, new AnonymousGuildUserSetting
+            {
+                GuildId = guildId,
+                UserId = user.Id,
+                IsAnonymous = false,
+            });
+        }
+        else
+        {
+            foreach (var setting in settings)
+            {
+                setting.IsAnonymous = false;
+                setting.AnonymousName = null;
+                setting.AnonymousAvatarUrl = null;
+                _databaseService.Update(AnonymousGuildUserSetting.TableName, setting);
+            }
+        }
+
+        await RespondAsync("匿名化を解除したよ！", ephemeral: true);
+    }
+}
+

--- a/TsDiscordBot.Core/Data/AnonymousGuildUserSetting.cs
+++ b/TsDiscordBot.Core/Data/AnonymousGuildUserSetting.cs
@@ -1,0 +1,13 @@
+namespace TsDiscordBot.Core.Data;
+
+public class AnonymousGuildUserSetting
+{
+    public const string TableName = "anonymous_guild_user_setting";
+
+    public int Id { get; set; }
+    public ulong GuildId { get; set; }
+    public ulong UserId { get; set; }
+    public bool IsAnonymous { get; set; }
+    public string? AnonymousName { get; set; }
+    public string? AnonymousAvatarUrl { get; set; }
+}

--- a/TsDiscordBot.Core/HostedService/AnonymousRelayService.cs
+++ b/TsDiscordBot.Core/HostedService/AnonymousRelayService.cs
@@ -1,0 +1,153 @@
+using System.Collections.Concurrent;
+using System.IO;
+using System.Net.Http;
+using Discord;
+using Discord.WebSocket;
+using Discord.Webhook;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using TsDiscordBot.Core.Data;
+using TsDiscordBot.Core.Services;
+using TsDiscordBot.Core.Utility;
+
+namespace TsDiscordBot.Core.HostedService;
+
+public class AnonymousRelayService : IHostedService
+{
+    private readonly DiscordSocketClient _client;
+    private readonly ILogger<AnonymousRelayService> _logger;
+    private readonly DatabaseService _databaseService;
+
+    private AnonymousGuildUserSetting[] _userCache = [];
+    private OverseaChannel[] _overseaChannelCache = [];
+    private DateTime _lastQueryTime = DateTime.MinValue;
+    private readonly TimeSpan _querySpan = TimeSpan.FromSeconds(5);
+
+    private readonly ConcurrentDictionary<ulong, DiscordWebhookClient> _webhookCache = new();
+
+    private async Task<DiscordWebhookClient> GetOrCreateWebhookClientAsync(ITextChannel channel)
+    {
+        if (_webhookCache.TryGetValue(channel.Id, out var cached))
+        {
+            return cached;
+        }
+
+        var hooks = await channel.GetWebhooksAsync();
+        var hook = hooks.FirstOrDefault(h => h.Name == "anonymous-relay")
+                   ?? await channel.CreateWebhookAsync("anonymous-relay");
+
+        var client = new DiscordWebhookClient(hook);
+        _webhookCache[channel.Id] = client;
+        return client;
+    }
+
+    public AnonymousRelayService(DiscordSocketClient client, ILogger<AnonymousRelayService> logger, DatabaseService databaseService)
+    {
+        _client = client;
+        _logger = logger;
+        _databaseService = databaseService;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        _client.MessageReceived += OnMessageReceivedAsync;
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        _client.MessageReceived -= OnMessageReceivedAsync;
+        return Task.CompletedTask;
+    }
+
+    private async Task OnMessageReceivedAsync(SocketMessage message)
+    {
+        try
+        {
+            if (message.Source != MessageSource.User || message.Channel is not SocketGuildChannel guildChannel)
+            {
+                return;
+            }
+
+            if (DateTime.Now - _lastQueryTime > _querySpan)
+            {
+                _userCache = _databaseService.FindAll<AnonymousGuildUserSetting>(AnonymousGuildUserSetting.TableName).ToArray();
+                _overseaChannelCache = _databaseService.FindAll<OverseaChannel>(OverseaChannel.TableName).ToArray();
+                _lastQueryTime = DateTime.Now;
+            }
+
+            if (_overseaChannelCache.Any(x => x.ChannelId == message.Channel.Id))
+            {
+                return; // Oversea relay has priority
+            }
+
+            var setting = _userCache.FirstOrDefault(x => x.GuildId == guildChannel.Guild.Id && x.UserId == message.Author.Id);
+            if (setting is null || !setting.IsAnonymous)
+            {
+                return;
+            }
+
+            var profile = AnonymousProfileProvider.GetProfile(message.Author.Id);
+            var discriminator = AnonymousProfileProvider.GetDiscriminator(message.Author.Id);
+            var baseName = string.IsNullOrEmpty(setting.AnonymousName) ? profile.Name : setting.AnonymousName!;
+            baseName = UserNameFixLogic.Fix(baseName);
+            var username = $"{baseName}#{discriminator}";
+            var avatarUrl = setting.AnonymousAvatarUrl ?? profile.AvatarUrl;
+
+            string? content = string.IsNullOrWhiteSpace(message.Content) ? null : message.Content;
+
+            List<(string FileName, string ContentType, byte[] Data)>? attachments = null;
+            if (message.Attachments.Any())
+            {
+                attachments = new List<(string, string, byte[])>();
+                using var http = new HttpClient();
+                foreach (var a in message.Attachments)
+                {
+                    try
+                    {
+                        var data = await http.GetByteArrayAsync(a.Url);
+                        attachments.Add((a.Filename, a.ContentType, data));
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, "Failed to download attachment {Url}", a.Url);
+                    }
+                }
+            }
+
+            try
+            {
+                await message.DeleteAsync();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to delete original message");
+            }
+
+            var client = await GetOrCreateWebhookClientAsync((ITextChannel)message.Channel);
+            if (attachments is { Count: > 0 })
+            {
+                var files = attachments
+                    .Select(a => new FileAttachment(new MemoryStream(a.Data), a.FileName, a.ContentType))
+                    .ToList();
+                try
+                {
+                    await client.SendFilesAsync(files, text: content, username: username, avatarUrl: avatarUrl);
+                }
+                finally
+                {
+                    foreach (var f in files)
+                        f.Stream.Dispose();
+                }
+            }
+            else
+            {
+                await client.SendMessageAsync(content ?? string.Empty, username: username, avatarUrl: avatarUrl);
+            }
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Failed to relay anonymous message.");
+        }
+    }
+}

--- a/TsDiscordBot.Entry/Program.cs
+++ b/TsDiscordBot.Entry/Program.cs
@@ -54,6 +54,7 @@ using IHost host = Host.CreateDefaultBuilder(args)
         services.AddHostedService<ReminderService>();
         services.AddHostedService<ImageReviseService>();
         services.AddHostedService<OverseaRelayService>();
+        services.AddHostedService<AnonymousRelayService>();
         services.AddHostedService<AutoDeleteService>();
     })
     .Build();


### PR DESCRIPTION
## Summary
- add commands to enable/disable guild-wide anonymization
- handle anonymous messages via webhook relay
- allow `/cc` to change profile for global or multi-server anonymity

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b98638eb28832db084ffcac47a36c0