### PR TITLE
Prioritize deletions before reactions

### DIFF
--- a/TsDiscordBot.Core/HostedService/TriggerReactionService.cs
+++ b/TsDiscordBot.Core/HostedService/TriggerReactionService.cs
@@ -40,7 +40,8 @@ public class TriggerReactionService : IHostedService
     {
         try
         {
-            if (message.Author.IsBot || message.Channel is not SocketGuildChannel guildChannel)
+            // Allow bot messages to trigger reactions; only skip non-guild channels
+            if (message.Channel is not SocketGuildChannel guildChannel)
             {
                 return;
             }

--- a/TsDiscordBot.Entry/Program.cs
+++ b/TsDiscordBot.Entry/Program.cs
@@ -46,15 +46,16 @@ using IHost host = Host.CreateDefaultBuilder(args)
         // Add hosted services
         services.AddHostedService<InteractionHandlingService>();
         services.AddHostedService<DiscordStartupService>();
-        services.AddHostedService<TriggerReactionService>();
+        // Message delete related services should run before reaction handling
         services.AddHostedService<BannedMessageCheckerService>();
+        services.AddHostedService<OverseaRelayService>();
+        services.AddHostedService<AnonymousRelayService>();
+        services.AddHostedService<TriggerReactionService>();
         services.AddHostedService<NauAriService>();
         services.AddHostedService<TsumugiService>();
         services.AddHostedService<AutoMessageService>();
         services.AddHostedService<ReminderService>();
         services.AddHostedService<ImageReviseService>();
-        services.AddHostedService<OverseaRelayService>();
-        services.AddHostedService<AnonymousRelayService>();
         services.AddHostedService<AutoDeleteService>();
     })
     .Build();


### PR DESCRIPTION
## Summary
- start deletion services before reaction service so deletions happen first
- allow trigger reactions to respond to bot messages

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b993603d20832dbea102eca9d7cae4