### PR TITLE
Add BeReal image history feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ It supports chat generation, automatic reactions, banned word detection, and sch
 - 長期記憶の追加・削除・一覧表示 / Manage long-term memories (add/remove/list)
 - 複数サーバー間で匿名メッセージを中継（Oversea） / Relay anonymous messages across servers (Oversea)
 - 「なう(20xx/xx/xx ...)」への自動応答 / Automatic response to messages starting with "なう(20xx/xx/xx ...)"
+- 画像投稿で過去の画像履歴を表示する BeReal モード / BeReal mode that shows past images when posting a new one
 
 ## 必要な環境変数 / Required Environment Variables
 - `DISCORD_TOKEN` : Discord ボットのトークン / Discord bot token

--- a/TsDiscordBot.Core/Commands/BeRealCommandModule.cs
+++ b/TsDiscordBot.Core/Commands/BeRealCommandModule.cs
@@ -1,0 +1,43 @@
+using System.Linq;
+using Discord.Interactions;
+using Microsoft.Extensions.Logging;
+using TsDiscordBot.Core.Data;
+using TsDiscordBot.Core.Services;
+
+namespace TsDiscordBot.Core.Commands;
+
+public class BeRealCommandModule : InteractionModuleBase<SocketInteractionContext>
+{
+    private readonly ILogger _logger;
+    private readonly DatabaseService _databaseService;
+
+    public BeRealCommandModule(ILogger<BeRealCommandModule> logger, DatabaseService databaseService)
+    {
+        _logger = logger;
+        _databaseService = databaseService;
+    }
+
+    [SlashCommand("enable-be-real", "画像を投稿すると過去の履歴が見られるようにします")]
+    public async Task EnableBeReal()
+    {
+        var guildId = Context.Guild.Id;
+        var channelId = Context.Channel.Id;
+
+        var exists = _databaseService
+            .FindAll<BeRealChannel>(BeRealChannel.TableName)
+            .Any(x => x.ChannelId == channelId);
+
+        if (!exists)
+        {
+            var data = new BeRealChannel
+            {
+                GuildId = guildId,
+                ChannelId = channelId,
+            };
+            _databaseService.Insert(BeRealChannel.TableName, data);
+        }
+
+        await RespondAsync("BeRealをこのチャンネルで有効にしたよ！");
+    }
+}
+

--- a/TsDiscordBot.Core/Data/BeRealChannel.cs
+++ b/TsDiscordBot.Core/Data/BeRealChannel.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace TsDiscordBot.Core.Data;
+
+public class BeRealChannel
+{
+    public const string TableName = "be_real_channel";
+
+    public int Id { get; set; }
+    public ulong GuildId { get; set; }
+    public ulong ChannelId { get; set; }
+}
+

--- a/TsDiscordBot.Core/Data/BeRealPost.cs
+++ b/TsDiscordBot.Core/Data/BeRealPost.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace TsDiscordBot.Core.Data;
+
+public class BeRealPost
+{
+    public const string TableName = "be_real_post";
+
+    public int Id { get; set; }
+    public ulong GuildId { get; set; }
+    public ulong ChannelId { get; set; }
+    public ulong UserId { get; set; }
+    public string ImageUrl { get; set; } = string.Empty;
+    public DateTime PostedAtUtc { get; set; }
+}
+

--- a/TsDiscordBot.Core/HostedService/BeRealService.cs
+++ b/TsDiscordBot.Core/HostedService/BeRealService.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Linq;
+using System.Text;
+using Discord.WebSocket;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using TsDiscordBot.Core.Data;
+using TsDiscordBot.Core.Services;
+
+namespace TsDiscordBot.Core.HostedService;
+
+public class BeRealService : IHostedService
+{
+    private readonly DiscordSocketClient _client;
+    private readonly ILogger<BeRealService> _logger;
+    private readonly DatabaseService _databaseService;
+
+    public BeRealService(DiscordSocketClient client, ILogger<BeRealService> logger, DatabaseService databaseService)
+    {
+        _client = client;
+        _logger = logger;
+        _databaseService = databaseService;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        _client.MessageReceived += OnMessageReceivedAsync;
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        _client.MessageReceived -= OnMessageReceivedAsync;
+        return Task.CompletedTask;
+    }
+
+    private async Task OnMessageReceivedAsync(SocketMessage message)
+    {
+        try
+        {
+            if (message.Author.IsBot || message.Channel is not SocketGuildChannel guildChannel)
+            {
+                return;
+            }
+
+            var attachments = message.Attachments
+                .Where(a => a.ContentType != null && a.ContentType.StartsWith("image/"))
+                .ToArray();
+
+            if (attachments.Length == 0)
+            {
+                return;
+            }
+
+            var channels = _databaseService.FindAll<BeRealChannel>(BeRealChannel.TableName);
+            if (!channels.Any(x => x.ChannelId == guildChannel.Id))
+            {
+                return;
+            }
+
+            var previous = _databaseService.FindAll<BeRealPost>(BeRealPost.TableName)
+                .Where(x => x.ChannelId == guildChannel.Id && x.UserId == message.Author.Id)
+                .OrderBy(x => x.PostedAtUtc)
+                .ToArray();
+
+            if (previous.Length > 0)
+            {
+                var builder = new StringBuilder();
+                builder.AppendLine($"{message.Author.Username}さんの過去の投稿:");
+                foreach (var p in previous)
+                {
+                    builder.AppendLine(p.ImageUrl);
+                }
+                await message.Channel.SendMessageAsync(builder.ToString());
+            }
+
+            foreach (var att in attachments)
+            {
+                var entry = new BeRealPost
+                {
+                    GuildId = guildChannel.Guild.Id,
+                    ChannelId = guildChannel.Id,
+                    UserId = message.Author.Id,
+                    ImageUrl = att.Url,
+                    PostedAtUtc = DateTime.UtcNow
+                };
+                _databaseService.Insert(BeRealPost.TableName, entry);
+            }
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Failed to process BeReal message");
+        }
+    }
+}
+

--- a/TsDiscordBot.Entry/Program.cs
+++ b/TsDiscordBot.Entry/Program.cs
@@ -53,6 +53,7 @@ using IHost host = Host.CreateDefaultBuilder(args)
         services.AddHostedService<TriggerReactionService>();
         services.AddHostedService<NauAriService>();
         services.AddHostedService<TsumugiService>();
+        services.AddHostedService<BeRealService>();
         services.AddHostedService<AutoMessageService>();
         services.AddHostedService<ReminderService>();
         services.AddHostedService<ImageReviseService>();


### PR DESCRIPTION
## Summary
- add /enable-be-real command to activate BeReal mode in a channel
- store image posts and show user's past images when they upload a new one
- document BeReal mode in README

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68ba6be285f0832da78e08fb9c2f55e9