### PR TITLE
feat: add bereal channel system

### DIFF
--- a/TsDiscordBot.Core/Commands/BeRealCommandModule.cs
+++ b/TsDiscordBot.Core/Commands/BeRealCommandModule.cs
@@ -1,0 +1,155 @@
+using System.Linq;
+using Discord;
+using Discord.Interactions;
+using Discord.WebSocket;
+using Microsoft.Extensions.Logging;
+using TsDiscordBot.Core.Data;
+using TsDiscordBot.Core.Services;
+
+namespace TsDiscordBot.Core.Commands;
+
+public class BeRealCommandModule : InteractionModuleBase<SocketInteractionContext>
+{
+    private readonly DatabaseService _databaseService;
+    private readonly ILogger _logger;
+
+    public BeRealCommandModule(DatabaseService databaseService, ILogger<BeRealCommandModule> logger)
+    {
+        _databaseService = databaseService;
+        _logger = logger;
+    }
+
+    [SlashCommand("be-real-initialize", "be realのチャンネルとロールを作成します。")]
+    public async Task Initialize()
+    {
+        var guild = Context.Guild;
+        if (guild is null)
+        {
+            await RespondAsync("This command must be used in a guild.");
+            return;
+        }
+
+        var existing = _databaseService
+            .FindAll<BeRealConfig>(BeRealConfig.TableName)
+            .FirstOrDefault(x => x.GuildId == guild.Id);
+
+        if (existing is not null)
+        {
+            await RespondAsync("be-real はすでに設定されています。");
+            return;
+        }
+
+        var role = await guild.CreateRoleAsync("BeReal-24h", GuildPermissions.None, null, false, null);
+        var everyone = guild.EveryoneRole;
+
+        var postChannel = await guild.CreateTextChannelAsync("be-real-post", props =>
+        {
+            props.PermissionOverwrites = new[]
+            {
+                new Overwrite(everyone.Id, PermissionTarget.Role,
+                    new OverwritePermissions(viewChannel: PermValue.Allow,
+                                             sendMessages: PermValue.Allow,
+                                             readMessageHistory: PermValue.Deny))
+            };
+        });
+
+        var feedChannel = await guild.CreateTextChannelAsync("be-real-feed", props =>
+        {
+            props.PermissionOverwrites = new[]
+            {
+                new Overwrite(everyone.Id, PermissionTarget.Role,
+                    new OverwritePermissions(viewChannel: PermValue.Deny)),
+                new Overwrite(role.Id, PermissionTarget.Role,
+                    new OverwritePermissions(viewChannel: PermValue.Allow,
+                                             sendMessages: PermValue.Deny,
+                                             readMessageHistory: PermValue.Allow))
+            };
+        });
+
+        var pinsChannel = await guild.CreateTextChannelAsync("be-real-pins", props =>
+        {
+            props.PermissionOverwrites = new[]
+            {
+                new Overwrite(everyone.Id, PermissionTarget.Role,
+                    new OverwritePermissions(viewChannel: PermValue.Allow,
+                                             sendMessages: PermValue.Deny,
+                                             readMessageHistory: PermValue.Allow))
+            };
+        });
+
+        var postMsg = await postChannel.SendMessageAsync(
+            "画像を投稿すると 24 時間 #be-real-feed を閲覧できます！");
+        await postMsg.PinAsync();
+
+        var feedMsg = await feedChannel.SendMessageAsync(
+            "#be-real-post から画像が転送されます。一般ユーザーの書き込み権限はありません。");
+        await feedMsg.PinAsync();
+
+        var config = new BeRealConfig
+        {
+            GuildId = guild.Id,
+            PostChannelId = postChannel.Id,
+            FeedChannelId = feedChannel.Id,
+            PinsChannelId = pinsChannel.Id,
+            RoleId = role.Id
+        };
+
+        _databaseService.Insert(BeRealConfig.TableName, config);
+
+        await RespondAsync("BeReal を初期化しました。");
+    }
+
+    [SlashCommand("be-real-destroy", "be real の設定を解除します。")]
+    public async Task Destroy()
+    {
+        var guild = Context.Guild;
+        if (guild is null)
+        {
+            await RespondAsync("This command must be used in a guild.");
+            return;
+        }
+
+        var config = _databaseService
+            .FindAll<BeRealConfig>(BeRealConfig.TableName)
+            .FirstOrDefault(x => x.GuildId == guild.Id);
+
+        if (config is null)
+        {
+            await RespondAsync("be-real は設定されていません。");
+            return;
+        }
+
+        if (guild.GetRole(config.RoleId) is SocketRole role)
+        {
+            await role.DeleteAsync();
+        }
+
+        if (guild.GetTextChannel(config.PostChannelId) is SocketTextChannel post)
+        {
+            await post.DeleteAsync();
+        }
+
+        if (guild.GetTextChannel(config.FeedChannelId) is SocketTextChannel feed)
+        {
+            await feed.DeleteAsync();
+        }
+
+        if (guild.GetTextChannel(config.PinsChannelId) is SocketTextChannel pins)
+        {
+            await pins.DeleteAsync();
+        }
+
+        var participants = _databaseService
+            .FindAll<BeRealParticipant>(BeRealParticipant.TableName)
+            .Where(x => x.GuildId == guild.Id)
+            .ToArray();
+        foreach (var p in participants)
+        {
+            _databaseService.Delete(BeRealParticipant.TableName, p.Id);
+        }
+
+        _databaseService.Delete(BeRealConfig.TableName, config.Id);
+
+        await RespondAsync("be-real の設定を削除しました。");
+    }
+}

--- a/TsDiscordBot.Core/Data/BeRealConfig.cs
+++ b/TsDiscordBot.Core/Data/BeRealConfig.cs
@@ -1,0 +1,13 @@
+namespace TsDiscordBot.Core.Data;
+
+public class BeRealConfig
+{
+    public const string TableName = "bereal-config";
+
+    public int Id { get; set; }
+    public ulong GuildId { get; set; }
+    public ulong PostChannelId { get; set; }
+    public ulong FeedChannelId { get; set; }
+    public ulong PinsChannelId { get; set; }
+    public ulong RoleId { get; set; }
+}

--- a/TsDiscordBot.Core/Data/BeRealParticipant.cs
+++ b/TsDiscordBot.Core/Data/BeRealParticipant.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace TsDiscordBot.Core.Data;
+
+public class BeRealParticipant
+{
+    public const string TableName = "bereal-participant";
+
+    public int Id { get; set; }
+    public ulong GuildId { get; set; }
+    public ulong UserId { get; set; }
+    public DateTime LastPostedAtUtc { get; set; }
+}

--- a/TsDiscordBot.Core/HostedService/BeRealService.cs
+++ b/TsDiscordBot.Core/HostedService/BeRealService.cs
@@ -1,0 +1,168 @@
+using System.Linq;
+using Discord;
+using Discord.WebSocket;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using TsDiscordBot.Core.Data;
+using TsDiscordBot.Core.Services;
+
+namespace TsDiscordBot.Core.HostedService;
+
+public class BeRealService : IHostedService
+{
+    private readonly DiscordSocketClient _client;
+    private readonly DatabaseService _databaseService;
+    private readonly ILogger<BeRealService> _logger;
+    private CancellationTokenSource? _cts;
+
+    public BeRealService(DiscordSocketClient client, DatabaseService databaseService, ILogger<BeRealService> logger)
+    {
+        _client = client;
+        _databaseService = databaseService;
+        _logger = logger;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        _client.MessageReceived += OnMessageReceivedAsync;
+        _cts = new CancellationTokenSource();
+        _ = Task.Run(() => TimerLoopAsync(_cts.Token));
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        _client.MessageReceived -= OnMessageReceivedAsync;
+        _cts?.Cancel();
+        return Task.CompletedTask;
+    }
+
+    private async Task OnMessageReceivedAsync(SocketMessage message)
+    {
+        try
+        {
+            if (message.Channel is not SocketGuildChannel guildChannel)
+            {
+                return;
+            }
+
+            if (message.Author.IsBot)
+            {
+                return;
+            }
+
+            var config = _databaseService
+                .FindAll<BeRealConfig>(BeRealConfig.TableName)
+                .FirstOrDefault(x => x.PostChannelId == guildChannel.Id);
+
+            if (config is null)
+            {
+                return;
+            }
+
+            if (!message.Attachments.Any(a => a.Width.HasValue))
+            {
+                return;
+            }
+
+            var guild = guildChannel.Guild;
+            var feedChannel = guild.GetTextChannel(config.FeedChannelId);
+            if (feedChannel is null)
+            {
+                return;
+            }
+
+            foreach (var attachment in message.Attachments.Where(a => a.Width.HasValue))
+            {
+                var embed = new EmbedBuilder()
+                    .WithAuthor(message.Author)
+                    .WithImageUrl(attachment.Url)
+                    .Build();
+
+                await feedChannel.SendMessageAsync(message.Author.Mention, embed: embed);
+            }
+
+            await message.DeleteAsync();
+
+            if (message.Author is SocketGuildUser guildUser)
+            {
+                var role = guild.GetRole(config.RoleId);
+                if (role is not null)
+                {
+                    await guildUser.AddRoleAsync(role);
+                }
+
+                var existing = _databaseService
+                    .FindAll<BeRealParticipant>(BeRealParticipant.TableName)
+                    .FirstOrDefault(x => x.GuildId == guild.Id && x.UserId == guildUser.Id);
+
+                if (existing is null)
+                {
+                    existing = new BeRealParticipant
+                    {
+                        GuildId = guild.Id,
+                        UserId = guildUser.Id,
+                        LastPostedAtUtc = DateTime.UtcNow
+                    };
+                    _databaseService.Insert(BeRealParticipant.TableName, existing);
+                }
+                else
+                {
+                    existing.LastPostedAtUtc = DateTime.UtcNow;
+                    _databaseService.Update(BeRealParticipant.TableName, existing);
+                }
+            }
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Failed to process be-real post");
+        }
+    }
+
+    private async Task TimerLoopAsync(CancellationToken token)
+    {
+        while (!token.IsCancellationRequested)
+        {
+            try
+            {
+                var participants = _databaseService
+                    .FindAll<BeRealParticipant>(BeRealParticipant.TableName)
+                    .ToArray();
+
+                foreach (var participant in participants)
+                {
+                    if (DateTime.UtcNow - participant.LastPostedAtUtc >= TimeSpan.FromHours(24))
+                    {
+                        var guild = _client.GetGuild(participant.GuildId);
+                        var config = _databaseService
+                            .FindAll<BeRealConfig>(BeRealConfig.TableName)
+                            .FirstOrDefault(x => x.GuildId == participant.GuildId);
+                        if (guild != null && config != null)
+                        {
+                            var user = guild.GetUser(participant.UserId);
+                            var role = guild.GetRole(config.RoleId);
+                            if (user != null && role != null)
+                            {
+                                await user.RemoveRoleAsync(role);
+                            }
+                        }
+
+                        _databaseService.Delete(BeRealParticipant.TableName, participant.Id);
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e, "Failed to revoke be-real roles");
+            }
+
+            try
+            {
+                await Task.Delay(TimeSpan.FromMinutes(30), token);
+            }
+            catch (TaskCanceledException)
+            {
+            }
+        }
+    }
+}

--- a/TsDiscordBot.Entry/Program.cs
+++ b/TsDiscordBot.Entry/Program.cs
@@ -57,6 +57,7 @@ using IHost host = Host.CreateDefaultBuilder(args)
         services.AddHostedService<ReminderService>();
         services.AddHostedService<ImageReviseService>();
         services.AddHostedService<AutoDeleteService>();
+        services.AddHostedService<BeRealService>();
     })
     .Build();
 


### PR DESCRIPTION
## Summary
- add `/be-real-initialize` and `/be-real-destroy` commands
- create background service to mirror images and revoke roles after 24h
- store be-real configuration and participants in LiteDB

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba74b13eb0832d8716f4f44805462e