### PR TITLE
Relay BeReal posts with link confirmation

### DIFF
--- a/TsDiscordBot.Core/HostedService/BeRealService.cs
+++ b/TsDiscordBot.Core/HostedService/BeRealService.cs
@@ -1,3 +1,4 @@
+using Discord;
 using Discord.WebSocket;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -71,9 +72,18 @@ public class BeRealService : IHostedService
             }
 
             var webhookClient = await WebHookWrapper.Default.GetOrCreateWebhookClientAsync(feedChannel, "be-real-relay");
-            await webhookClient.RelayMessageAsync(message, message.Content, logger:_logger);
+            var feedMessageId = await webhookClient.RelayMessageAsync(message, message.Content, logger:_logger);
 
             await message.DeleteAsync();
+
+            if (feedMessageId is { } id)
+            {
+                var link = $"https://discord.com/channels/{guild.Id}/{feedChannel.Id}/{id}";
+                if (message.Channel is IMessageChannel postChannel)
+                {
+                    await postChannel.SendMessageAsync($"Feedにメッセージを送信しました！{link}");
+                }
+            }
 
             if (message.Author is SocketGuildUser guildUser)
             {

--- a/TsDiscordBot.Core/Services/WebHookWrapper.cs
+++ b/TsDiscordBot.Core/Services/WebHookWrapper.cs
@@ -42,7 +42,7 @@ namespace TsDiscordBot.Core.Services
             _client = client;
         }
 
-        public async Task RelayMessageAsync(SocketMessage socketMessage, string? content, string? author = null, string? avatarUrl = null, ILogger? logger = null)
+        public async Task<ulong?> RelayMessageAsync(SocketMessage socketMessage, string? content, string? author = null, string? avatarUrl = null, ILogger? logger = null)
         {
             try
             {
@@ -70,6 +70,8 @@ namespace TsDiscordBot.Core.Services
                 }
 
 
+                ulong? messageId = null;
+
                 if (attachments is { Count: > 0 })
                 {
                     var files = attachments
@@ -77,7 +79,7 @@ namespace TsDiscordBot.Core.Services
                         .ToList();
                     try
                     {
-                        await _client.SendFilesAsync(files, text: content, username: author, avatarUrl: avatarUrl);
+                        messageId = await _client.SendFilesAsync(files, text: content, username: author, avatarUrl: avatarUrl);
                     }
                     catch(Exception e)
                     {
@@ -95,7 +97,7 @@ namespace TsDiscordBot.Core.Services
                 {
                     try
                     {
-                        await _client.SendMessageAsync(content ?? string.Empty, username: author, avatarUrl: avatarUrl);
+                        messageId = await _client.SendMessageAsync(content ?? string.Empty, username: author, avatarUrl: avatarUrl);
                     }
                     catch(Exception e)
                     {
@@ -103,10 +105,13 @@ namespace TsDiscordBot.Core.Services
                     }
 
                 }
+
+                return messageId;
             }
             catch(Exception e)
             {
                 logger?.LogError(e, "Error while relaying message");
+                return null;
             }
         }
     }


### PR DESCRIPTION
## Summary
- capture webhook message IDs when relaying BeReal posts
- notify BeReal post channel with link to relayed feed message

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bd512b7d94832d9b1b48f8c269292f