### PR TITLE
Require admin for BeReal commands

### DIFF
--- a/TsDiscordBot.Core/Commands/BeRealCommandModule.cs
+++ b/TsDiscordBot.Core/Commands/BeRealCommandModule.cs
@@ -19,6 +19,7 @@ public class BeRealCommandModule : InteractionModuleBase<SocketInteractionContex
     }
 
     [SlashCommand("be-real-initialize", "be realのチャンネルとロールを作成します。")]
+    [RequireUserPermission(GuildPermission.Administrator)]
     public async Task Initialize()
     {
         var guild = Context.Guild;
@@ -87,6 +88,7 @@ public class BeRealCommandModule : InteractionModuleBase<SocketInteractionContex
     }
 
     [SlashCommand("be-real-destroy", "be real の設定を解除します。")]
+    [RequireUserPermission(GuildPermission.Administrator)]
     public async Task Destroy()
     {
         var guild = Context.Guild;


### PR DESCRIPTION
## Summary
- restrict `be-real-initialize` and `be-real-destroy` slash commands to administrators

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bd50faf6dc832dac7590ac618f9b2d