### PR TITLE
ci: trigger docs workflow on web changes

### DIFF
--- a/.github/workflows/webpage-publish.yml
+++ b/.github/workflows/webpage-publish.yml
@@ -1,6 +1,11 @@
 name: Build docs & open PR
 
 on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'web/**'
   workflow_dispatch:
     inputs:
       note:
@@ -11,6 +16,7 @@ on:
 permissions:
   contents: write         # 変更のコミット/プッシュに必要
   pull-requests: write    # PR 作成に必要
+  workflow: write         # 後続ワークフローをトリガーするために必要
 
 concurrency:
   group: update-docs


### PR DESCRIPTION
## Summary
- run docs workflow automatically when `web/` files change
- allow the workflow to trigger CI tests

## Testing
- `dotnet restore Develop.sln`
- `dotnet build Develop.sln --no-restore`
- `dotnet test Develop.sln --no-build --verbosity normal`


------
https://chatgpt.com/codex/tasks/task_e_68be9a878d50832db95bdd77b07b1643