### PR TITLE
fix: add image module declarations

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, type ReactNode } from "react";
 
-import Header from "./Header.tsx";
-import AutoPlayVideo from "./components/AutoPlayVideo.tsx";
+import Header from "./Header";
+import AutoPlayVideo from "./components/AutoPlayVideo";
 
 import headerIcon from "./assets/hero.png";
 import githubIcon from "./assets/github.svg";

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { createRoot } from 'react-dom/client'
-import App from './App.tsx'
+import App from './App'
 import './index.css'
 
 createRoot(document.getElementById('root')!).render(<App />)

--- a/web/src/vite-env.d.ts
+++ b/web/src/vite-env.d.ts
@@ -1,0 +1,11 @@
+/// <reference types="vite/client" />
+
+declare module "*.png" {
+  const src: string;
+  export default src;
+}
+
+declare module "*.svg" {
+  const src: string;
+  export default src;
+}


### PR DESCRIPTION
## Summary
- declare PNG and SVG asset modules for Vite
- drop .tsx extensions from local imports

## Testing
- `npm run lint`
- `npx tsc`

------
https://chatgpt.com/codex/tasks/task_e_68bea118a9b4832d8f84a289a5b9f66e