### PR TITLE
Add daily topic scheduling

### DIFF
--- a/TsDiscordBot.Core/Commands/DailyTopicCommandModule.cs
+++ b/TsDiscordBot.Core/Commands/DailyTopicCommandModule.cs
@@ -1,0 +1,95 @@
+using Discord;
+using Discord.Interactions;
+using Microsoft.Extensions.Logging;
+using TsDiscordBot.Core.Data;
+using TsDiscordBot.Core.Services;
+
+namespace TsDiscordBot.Core.Commands;
+
+public class DailyTopicCommandModule : InteractionModuleBase<SocketInteractionContext>
+{
+    private readonly DatabaseService _databaseService;
+
+    public DailyTopicCommandModule(ILogger<DailyTopicCommandModule> logger, DatabaseService databaseService)
+    {
+        _ = logger;
+        _databaseService = databaseService;
+    }
+
+    [SlashCommand("enable-daily-topic", "rand_topicsから日替わりトピックを投稿します。")]
+    [RequireUserPermission(GuildPermission.Administrator)]
+    public async Task EnableDailyTopic([Summary("time", "投稿する時刻 (HH:mm, 日本時間 GMT+9:00)")] string? time = null)
+    {
+        var guildId = Context.Guild.Id;
+        var channelId = Context.Channel.Id;
+
+        TimeSpan postAt;
+        if (string.IsNullOrWhiteSpace(time))
+        {
+            postAt = new TimeSpan(7, 0, 0);
+        }
+        else if (!TimeSpan.TryParse(time, out postAt))
+        {
+            await RespondAsync("時刻の形式が正しくないよ！（例: 07:00）");
+            return;
+        }
+
+        TimeZoneInfo jst;
+        try
+        {
+            jst = TimeZoneInfo.FindSystemTimeZoneById("Asia/Tokyo");
+        }
+        catch (TimeZoneNotFoundException)
+        {
+            jst = TimeZoneInfo.FindSystemTimeZoneById("Tokyo Standard Time");
+        }
+
+        var nowJst = TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, jst);
+        var lastPostedUtc = DateTime.UtcNow;
+        if (nowJst.TimeOfDay < postAt)
+        {
+            lastPostedUtc = lastPostedUtc.AddDays(-1);
+        }
+
+        var existing = _databaseService
+            .FindAll<DailyTopicChannel>(DailyTopicChannel.TableName)
+            .FirstOrDefault(x => x.GuildId == guildId);
+
+        if (existing is not null)
+        {
+            _databaseService.Delete(DailyTopicChannel.TableName, existing.Id);
+        }
+
+        var data = new DailyTopicChannel
+        {
+            GuildId = guildId,
+            ChannelId = channelId,
+            PostAtJst = postAt,
+            LastPostedUtc = lastPostedUtc
+        };
+
+        _databaseService.Insert(DailyTopicChannel.TableName, data);
+
+        await RespondAsync($"毎日 {postAt:hh\\:mm} にこのチャンネルでトピックを投稿するように設定したよ！");
+    }
+
+    [SlashCommand("disable-daily-topic", "日替わりトピックの投稿を停止します。")]
+    [RequireUserPermission(GuildPermission.Administrator)]
+    public async Task DisableDailyTopic()
+    {
+        var guildId = Context.Guild.Id;
+
+        var existing = _databaseService
+            .FindAll<DailyTopicChannel>(DailyTopicChannel.TableName)
+            .FirstOrDefault(x => x.GuildId == guildId);
+
+        if (existing is null)
+        {
+            await RespondAsync("このサーバーではdaily-topicは設定されていないよ！");
+            return;
+        }
+
+        _databaseService.Delete(DailyTopicChannel.TableName, existing.Id);
+        await RespondAsync("daily-topicを解除したよ！");
+    }
+}

--- a/TsDiscordBot.Core/Data/DailyTopicChannel.cs
+++ b/TsDiscordBot.Core/Data/DailyTopicChannel.cs
@@ -1,0 +1,12 @@
+namespace TsDiscordBot.Core.Data;
+
+public class DailyTopicChannel
+{
+    public const string TableName = "daily_topic_channel";
+
+    public int Id { get; set; }
+    public ulong GuildId { get; set; }
+    public ulong ChannelId { get; set; }
+    public TimeSpan PostAtJst { get; set; }
+    public DateTime LastPostedUtc { get; set; }
+}

--- a/TsDiscordBot.Core/HostedService/DailyTopicService.cs
+++ b/TsDiscordBot.Core/HostedService/DailyTopicService.cs
@@ -43,7 +43,8 @@ public class DailyTopicService : BackgroundService
                 foreach (var config in configs)
                 {
                     var nowJst = TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, jst);
-                    var lastPostedJst = TimeZoneInfo.ConvertTimeFromUtc(config.LastPostedUtc, jst);
+                    var lastPostedUtc = DateTime.SpecifyKind(config.LastPostedUtc, DateTimeKind.Utc);
+                    var lastPostedJst = TimeZoneInfo.ConvertTimeFromUtc(lastPostedUtc, jst);
                     if (nowJst.Date > lastPostedJst.Date && nowJst.TimeOfDay >= config.PostAtJst)
                     {
                         var guildId = config.GuildId;

--- a/TsDiscordBot.Core/HostedService/DailyTopicService.cs
+++ b/TsDiscordBot.Core/HostedService/DailyTopicService.cs
@@ -1,0 +1,75 @@
+using Discord.WebSocket;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using TsDiscordBot.Core.Data;
+using TsDiscordBot.Core.Services;
+
+namespace TsDiscordBot.Core.HostedService;
+
+public class DailyTopicService : BackgroundService
+{
+    private readonly DiscordSocketClient _client;
+    private readonly ILogger<DailyTopicService> _logger;
+    private readonly DatabaseService _databaseService;
+    private readonly RandTopicService _randTopicService;
+
+    public DailyTopicService(DiscordSocketClient client, ILogger<DailyTopicService> logger,
+        DatabaseService databaseService, RandTopicService randTopicService)
+    {
+        _client = client;
+        _logger = logger;
+        _databaseService = databaseService;
+        _randTopicService = randTopicService;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        TimeZoneInfo jst;
+        try
+        {
+            jst = TimeZoneInfo.FindSystemTimeZoneById("Asia/Tokyo");
+        }
+        catch (TimeZoneNotFoundException)
+        {
+            jst = TimeZoneInfo.FindSystemTimeZoneById("Tokyo Standard Time");
+        }
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                var configs = _databaseService.FindAll<DailyTopicChannel>(DailyTopicChannel.TableName).ToArray();
+
+                foreach (var config in configs)
+                {
+                    var nowJst = TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, jst);
+                    var lastPostedJst = TimeZoneInfo.ConvertTimeFromUtc(config.LastPostedUtc, jst);
+                    if (nowJst.Date > lastPostedJst.Date && nowJst.TimeOfDay >= config.PostAtJst)
+                    {
+                        var guildId = config.GuildId;
+                        SocketTextChannel? channel = _client.GetChannel(config.ChannelId) as SocketTextChannel
+                            ?? _client.GetGuild(guildId)?.GetTextChannel(config.ChannelId);
+
+                        if (channel is not null)
+                        {
+                            var topic = _randTopicService.GetTopic(nowJst);
+                            if (!string.IsNullOrEmpty(topic))
+                            {
+                                await channel.SendMessageAsync(topic);
+                            }
+
+                            config.LastPostedUtc = DateTime.UtcNow;
+                            _databaseService.Update(DailyTopicChannel.TableName, config);
+                        }
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e, "Failed to send daily topic");
+            }
+
+            await Task.Delay(TimeSpan.FromMinutes(1), stoppingToken);
+        }
+    }
+}

--- a/TsDiscordBot.Core/Services/RandTopicService.cs
+++ b/TsDiscordBot.Core/Services/RandTopicService.cs
@@ -1,0 +1,50 @@
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text.Json;
+
+namespace TsDiscordBot.Core.Services;
+
+public class RandTopicService
+{
+    private readonly Dictionary<string, string> _topics;
+
+    public RandTopicService()
+    {
+        _topics = new Dictionary<string, string>();
+        var assembly = Assembly.GetExecutingAssembly();
+        var resourceName = assembly.GetManifestResourceNames()
+            .FirstOrDefault(n => n.EndsWith("rand_topics.json"));
+        if (resourceName is null)
+        {
+            return;
+        }
+        using Stream? stream = assembly.GetManifestResourceStream(resourceName);
+        if (stream is null)
+        {
+            return;
+        }
+        using var reader = new StreamReader(stream);
+        var json = reader.ReadToEnd();
+        var list = JsonSerializer.Deserialize<List<Topic>>(json);
+        if (list is null)
+        {
+            return;
+        }
+        foreach (var t in list)
+        {
+            _topics[t.Date] = t.Text;
+        }
+    }
+
+    public string? GetTopic(DateTime dateJst)
+    {
+        var key = $"{dateJst.Month}/{dateJst.Day}";
+        return _topics.TryGetValue(key, out var text) ? text : null;
+    }
+
+    private class Topic
+    {
+        public string Date { get; set; } = "";
+        public string Text { get; set; } = "";
+    }
+}

--- a/TsDiscordBot.Entry/Program.cs
+++ b/TsDiscordBot.Entry/Program.cs
@@ -34,6 +34,7 @@ using IHost host = Host.CreateDefaultBuilder(args)
         services.AddSingleton<DatabaseService>();
         services.AddSingleton<OpenAIService>();
         services.AddSingleton<IUserCommandLimitService, UserCommandLimitService>();
+        services.AddSingleton<RandTopicService>();
         services.AddSingleton<IOpenAIImageService>(_ =>
         {
             var opts = new OpenAIImageOptions
@@ -54,6 +55,7 @@ using IHost host = Host.CreateDefaultBuilder(args)
         services.AddHostedService<NauAriService>();
         services.AddHostedService<TsumugiService>();
         services.AddHostedService<AutoMessageService>();
+        services.AddHostedService<DailyTopicService>();
         services.AddHostedService<ReminderService>();
         services.AddHostedService<ImageReviseService>();
         services.AddHostedService<AutoDeleteService>();


### PR DESCRIPTION
## Summary
- add `/enable-daily-topic` and `/disable-daily-topic` commands
- schedule daily topic messages based on rand_topics data
- load rand_topics.json into service for date-based lookup

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c0f676c0f4832d9bc1590c80e59d50