### PR TITLE
Fix UTC conversion for last daily topic timestamp

### DIFF
--- a/TsDiscordBot.Core/HostedService/DailyTopicService.cs
+++ b/TsDiscordBot.Core/HostedService/DailyTopicService.cs
@@ -43,7 +43,8 @@ public class DailyTopicService : BackgroundService
                 foreach (var config in configs)
                 {
                     var nowJst = TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, jst);
-                    var lastPostedJst = TimeZoneInfo.ConvertTimeFromUtc(config.LastPostedUtc, jst);
+                    var lastPostedUtc = DateTime.SpecifyKind(config.LastPostedUtc, DateTimeKind.Utc);
+                    var lastPostedJst = TimeZoneInfo.ConvertTimeFromUtc(lastPostedUtc, jst);
                     if (nowJst.Date > lastPostedJst.Date && nowJst.TimeOfDay >= config.PostAtJst)
                     {
                         var guildId = config.GuildId;


### PR DESCRIPTION
## Summary
- ensure LastPostedUtc is treated as UTC before converting to target timezone

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c0f9664b4c832da001ced1f61dcb3a