### PR TITLE
Add debug command to trigger daily topic

### DIFF
--- a/TsDiscordBot.Core/Commands/DailyTopicCommandModule.cs
+++ b/TsDiscordBot.Core/Commands/DailyTopicCommandModule.cs
@@ -1,5 +1,6 @@
 using Discord;
 using Discord.Interactions;
+using Discord.WebSocket;
 using Microsoft.Extensions.Logging;
 using TsDiscordBot.Core.Data;
 using TsDiscordBot.Core.Services;
@@ -9,11 +10,13 @@ namespace TsDiscordBot.Core.Commands;
 public class DailyTopicCommandModule : InteractionModuleBase<SocketInteractionContext>
 {
     private readonly DatabaseService _databaseService;
+    private readonly RandTopicService _randTopicService;
 
-    public DailyTopicCommandModule(ILogger<DailyTopicCommandModule> logger, DatabaseService databaseService)
+    public DailyTopicCommandModule(ILogger<DailyTopicCommandModule> logger, DatabaseService databaseService, RandTopicService randTopicService)
     {
         _ = logger;
         _databaseService = databaseService;
+        _randTopicService = randTopicService;
     }
 
     [SlashCommand("enable-daily-topic", "rand_topicsから日替わりトピックを投稿します。")]
@@ -71,6 +74,54 @@ public class DailyTopicCommandModule : InteractionModuleBase<SocketInteractionCo
         _databaseService.Insert(DailyTopicChannel.TableName, data);
 
         await RespondAsync($"毎日 {postAt:hh\\:mm} にこのチャンネルでトピックを投稿するように設定したよ！");
+    }
+
+    [SlashCommand("debug-daily-topic", "今日の日付に基づくdaily-topicを今すぐ実行します。(DBの更新無し)")]
+    public async Task DebugDailyTopic()
+    {
+        var guildId = Context.Guild.Id;
+
+        var config = _databaseService
+            .FindAll<DailyTopicChannel>(DailyTopicChannel.TableName)
+            .FirstOrDefault(x => x.GuildId == guildId);
+
+        if (config is null)
+        {
+            await RespondAsync("このサーバーではdaily-topicは設定されていないよ！");
+            return;
+        }
+
+        SocketTextChannel? channel = Context.Client.GetChannel(config.ChannelId) as SocketTextChannel
+            ?? Context.Guild.GetTextChannel(config.ChannelId);
+
+        if (channel is null)
+        {
+            await RespondAsync("設定されているチャンネルが見つからないよ！");
+            return;
+        }
+
+        TimeZoneInfo jst;
+        try
+        {
+            jst = TimeZoneInfo.FindSystemTimeZoneById("Asia/Tokyo");
+        }
+        catch (TimeZoneNotFoundException)
+        {
+            jst = TimeZoneInfo.FindSystemTimeZoneById("Tokyo Standard Time");
+        }
+
+        var nowJst = TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, jst);
+        var topic = _randTopicService.GetTopic(nowJst);
+
+        if (string.IsNullOrEmpty(topic))
+        {
+            await RespondAsync("今日のトピックが見つからないよ！");
+            return;
+        }
+
+        await channel.SendMessageAsync(topic);
+
+        await RespondAsync($"チャンネル<#{config.ChannelId}>でdaily-topicを送信したよ！");
     }
 
     [SlashCommand("disable-daily-topic", "日替わりトピックの投稿を停止します。")]


### PR DESCRIPTION
## Summary
- add `/debug-daily-topic` command to send today's topic without database update
- wire `RandTopicService` into `DailyTopicCommandModule`

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c11c89d080832db23c51f3e731ec6c