### PR TITLE
Add unit test for RandTopicService

### DIFF
--- a/TsDiscordBot.Core/Services/RandTopicService.cs
+++ b/TsDiscordBot.Core/Services/RandTopicService.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Reflection;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace TsDiscordBot.Core.Services;
 
@@ -44,7 +45,9 @@ public class RandTopicService
 
     private class Topic
     {
+        [JsonPropertyName("date")]
         public string Date { get; set; } = "";
+        [JsonPropertyName("text")]
         public string Text { get; set; } = "";
     }
 }

--- a/TsDiscordBot.Tests/RandTopicServiceTests.cs
+++ b/TsDiscordBot.Tests/RandTopicServiceTests.cs
@@ -1,0 +1,16 @@
+using System;
+using TsDiscordBot.Core.Services;
+using Xunit;
+
+namespace TsDiscordBot.Tests;
+
+public class RandTopicServiceTests
+{
+    [Fact]
+    public void GetTopic_ReturnsTopicForKnownDate()
+    {
+        var service = new RandTopicService();
+        var topic = service.GetTopic(new DateTime(2024, 1, 1));
+        Assert.Equal("お正月マジぱねぇ🎍✨みんなお年玉どんくらい貰ってた？💸てか今なら何に使うん？", topic);
+    }
+}


### PR DESCRIPTION
## Summary
- ensure RandTopicService parses embedded JSON correctly using JsonPropertyName attributes
- test topic lookup by date with RandTopicService

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c13b6ea13c832daabf7b4f55aee4e4