### PR TITLE
feat: add per-guild banned word timeout settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ It supports chat generation, automatic reactions, banned word detection, and sch
 - 複数禁止ワードの一括登録 / Bulk-register multiple banned words
 - 禁止テキストモードの設定 (/set-banned-text-mode hide|delete)
 - 禁止テキスト機能の有効/無効切り替え (/set-banned-text-enabled true|false)
+- 不適切発言のタイムアウト設定 (/setting-banned-words <enabled> <count> <within> <timeout>)
 - 一定時間後にメッセージを自動削除 / Automatically delete messages after a set time
 - 会話を促す自動メッセージ投稿 / Posts prompts automatically to encourage conversation
 - AI を使った画像生成・編集 / Generate and edit images with AI

--- a/TsDiscordBot.Core/Data/BannedWordTimeoutSetting.cs
+++ b/TsDiscordBot.Core/Data/BannedWordTimeoutSetting.cs
@@ -1,0 +1,13 @@
+namespace TsDiscordBot.Core.Data
+{
+    public class BannedWordTimeoutSetting
+    {
+        public const string TableName = "BannedWordTimeoutSettings";
+        public int Id { get; set; }
+        public ulong GuildId { get; set; }
+        public bool IsEnabled { get; set; } = true;
+        public int Count { get; set; } = 5;
+        public int WindowMinutes { get; set; } = 5;
+        public int TimeoutMinutes { get; set; } = 1;
+    }
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -79,6 +79,7 @@ const commands: { name: string; desc: string }[] = [
   { name: "/export-banned-words", desc: "登録されている禁止ワードをCSV形式で出力します。" },
   { name: "/set-banned-text-mode", desc: "禁止テキストの処理モードを設定します。(hide/delete)" },
   { name: "/set-banned-text-enabled", desc: "禁止テキスト機能を有効/無効にします。" },
+  { name: "/setting-banned-words", desc: "不適切発言のタイムアウト設定を変更します。" },
   { name: "/auto-message", desc: "AIで会話を促す自動メッセージを設定します。" },
   { name: "/show-auto-message", desc: "AIで会話を促す自動メッセージの現在の設定を表示します。" },
   { name: "/debug-auto-message", desc: "デバッグ用に自動メッセージを今すぐ送信します。" },


### PR DESCRIPTION
## Summary
- allow configuring banned word timeout settings per guild
- add `/setting-banned-words` command to manage timeout
- document new command

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c2c881bb20832da5c890090ed008e4