### PR TITLE
Fix video attachments being dropped in anonymous relay

### DIFF
--- a/TsDiscordBot.Core/HostedService/AnonymousRelayService.cs
+++ b/TsDiscordBot.Core/HostedService/AnonymousRelayService.cs
@@ -126,7 +126,7 @@ public class AnonymousRelayService : IHostedService
             if (attachments is { Count: > 0 })
             {
                 var files = attachments
-                    .Select(a => new FileAttachment(new MemoryStream(a.Data), a.FileName, a.ContentType))
+                    .Select(a => new FileAttachment(new MemoryStream(a.Data), a.FileName))
                     .ToList();
                 try
                 {

--- a/TsDiscordBot.Core/Services/WebHookWrapper.cs
+++ b/TsDiscordBot.Core/Services/WebHookWrapper.cs
@@ -71,7 +71,7 @@ namespace TsDiscordBot.Core.Services
                 if (attachments is { Count: > 0 })
                 {
                     var files = attachments
-                        .Select(a => new FileAttachment(new MemoryStream(a.Data), a.FileName, a.ContentType))
+                        .Select(a => new FileAttachment(new MemoryStream(a.Data), a.FileName))
                         .ToList();
                     try
                     {


### PR DESCRIPTION
## Summary
- fix anonymous and oversea relays dropping video attachments by not setting file description to MIME type

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c3cb374408832d8e69768abf85cefc