### PR TITLE
Fix avatar retrieval after disabling oversea anonymity

### DIFF
--- a/TsDiscordBot.Core/HostedService/OverseaRelayService.cs
+++ b/TsDiscordBot.Core/HostedService/OverseaRelayService.cs
@@ -90,7 +90,7 @@ public class OverseaRelayService : IHostedService
             else
             {
                 username = DiscordUtility.GetAuthorNameFromMessage(message);
-                avatarUrl = DiscordUtility.GetAuthorNameFromMessage(message);
+                avatarUrl = DiscordUtility.GetAvatarUrlFromMessage(message);
             }
 
             List<Task> tasks =


### PR DESCRIPTION
## Summary
- ensure oversea relay uses correct avatar URL when anonymity is disabled

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c43a5d1f00832da1d29921611ef08c