### PR TITLE
Add basic blackjack game logic

### DIFF
--- a/TsDiscordBot.Core/Game/BlackJack/BlackJackGame.cs
+++ b/TsDiscordBot.Core/Game/BlackJack/BlackJackGame.cs
@@ -1,0 +1,186 @@
+using System.Collections.Generic;
+
+namespace TsDiscordBot.Core.Game.BlackJack;
+
+public enum GameOutcome
+{
+    PlayerWin,
+    DealerWin,
+    Push
+}
+
+public sealed record GameResult(GameOutcome Outcome, int Payout, IReadOnlyList<Card> DealerCards, IReadOnlyList<Card> PlayerCards);
+
+public class BlackJackGame
+{
+    private readonly Deck _deck;
+    private readonly List<Card> _dealerHand = [];
+    private readonly List<Card> _playerHand = [];
+
+    public int Bet { get; }
+    public bool IsFinished { get; private set; }
+    public bool DoubleDowned { get; private set; }
+    public GameResult? Result { get; private set; }
+
+    public IReadOnlyList<Card> DealerCards => _dealerHand.AsReadOnly();
+    public IReadOnlyList<Card> PlayerCards => _playerHand.AsReadOnly();
+    public Card DealerVisibleCard => _dealerHand[0];
+
+    public BlackJackGame(int bet, Deck? deck = null)
+    {
+        Bet = bet;
+        _deck = deck ?? new Deck();
+        _playerHand.Add(_deck.Draw());
+        _dealerHand.Add(_deck.Draw());
+        _playerHand.Add(_deck.Draw());
+        _dealerHand.Add(_deck.Draw());
+
+        if (CalculateScore(_playerHand) == 21)
+        {
+            Stand();
+        }
+    }
+
+    public void Hit()
+    {
+        if (IsFinished)
+        {
+            return;
+        }
+
+        _playerHand.Add(_deck.Draw());
+        if (CalculateScore(_playerHand) > 21)
+        {
+            IsFinished = true;
+            Result = BuildResult(GameOutcome.DealerWin);
+        }
+    }
+
+    public void Stand()
+    {
+        if (IsFinished)
+        {
+            return;
+        }
+
+        PlayDealerTurn();
+        IsFinished = true;
+        Result = BuildResult(DetermineOutcome());
+    }
+
+    public void DoubleDown()
+    {
+        if (IsFinished || DoubleDowned || _playerHand.Count != 2)
+        {
+            return;
+        }
+
+        DoubleDowned = true;
+        _playerHand.Add(_deck.Draw());
+        if (CalculateScore(_playerHand) > 21)
+        {
+            IsFinished = true;
+            Result = BuildResult(GameOutcome.DealerWin);
+            return;
+        }
+
+        PlayDealerTurn();
+        IsFinished = true;
+        Result = BuildResult(DetermineOutcome());
+    }
+
+    public void Surrender()
+    {
+        if (IsFinished)
+        {
+            return;
+        }
+
+        IsFinished = true;
+        Result = BuildResult(GameOutcome.DealerWin);
+    }
+
+    private void PlayDealerTurn()
+    {
+        while (CalculateScore(_dealerHand) < 17)
+        {
+            _dealerHand.Add(_deck.Draw());
+        }
+    }
+
+    private GameOutcome DetermineOutcome()
+    {
+        var player = CalculateScore(_playerHand);
+        var dealer = CalculateScore(_dealerHand);
+
+        if (player > 21)
+        {
+            return GameOutcome.DealerWin;
+        }
+
+        if (dealer > 21)
+        {
+            return GameOutcome.PlayerWin;
+        }
+
+        if (player > dealer)
+        {
+            return GameOutcome.PlayerWin;
+        }
+
+        if (player < dealer)
+        {
+            return GameOutcome.DealerWin;
+        }
+
+        return GameOutcome.Push;
+    }
+
+    private GameResult BuildResult(GameOutcome outcome)
+    {
+        var payout = outcome switch
+        {
+            GameOutcome.PlayerWin => DoubleDowned ? Bet * 4 : Bet * 2,
+            GameOutcome.Push => Bet,
+            _ => 0
+        };
+
+        return new GameResult(outcome, payout, DealerCards, PlayerCards);
+    }
+
+    public static int CalculateScore(IEnumerable<Card> hand)
+    {
+        var score = 0;
+        var aceCount = 0;
+
+        foreach (var card in hand)
+        {
+            switch (card.Rank)
+            {
+                case Rank.Ace:
+                    aceCount++;
+                    break;
+                case >= Rank.Two and <= Rank.Ten:
+                    score += (int)card.Rank;
+                    break;
+                default:
+                    score += 10;
+                    break;
+            }
+        }
+
+        for (var i = 0; i < aceCount; i++)
+        {
+            if (score + 11 <= 21 - (aceCount - 1 - i))
+            {
+                score += 11;
+            }
+            else
+            {
+                score += 1;
+            }
+        }
+
+        return score;
+    }
+}

--- a/TsDiscordBot.Core/Game/BlackJack/Card.cs
+++ b/TsDiscordBot.Core/Game/BlackJack/Card.cs
@@ -1,0 +1,28 @@
+namespace TsDiscordBot.Core.Game.BlackJack;
+
+public enum Suit
+{
+    Clubs,
+    Diamonds,
+    Hearts,
+    Spades
+}
+
+public enum Rank
+{
+    Ace = 1,
+    Two,
+    Three,
+    Four,
+    Five,
+    Six,
+    Seven,
+    Eight,
+    Nine,
+    Ten,
+    Jack,
+    Queen,
+    King
+}
+
+public readonly record struct Card(Rank Rank, Suit Suit);

--- a/TsDiscordBot.Core/Game/BlackJack/Deck.cs
+++ b/TsDiscordBot.Core/Game/BlackJack/Deck.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+
+namespace TsDiscordBot.Core.Game.BlackJack;
+
+public class Deck
+{
+    private Stack<Card> _cards;
+    private static readonly Random Rng = new();
+
+    public Deck() : this(CreateShuffledDeck())
+    {
+    }
+
+    public Deck(IEnumerable<Card> cards)
+    {
+        _cards = new Stack<Card>(cards.Reverse());
+    }
+
+    private static IEnumerable<Card> CreateShuffledDeck()
+    {
+        var cards = new List<Card>();
+        foreach (var suit in Enum.GetValues<Suit>())
+        {
+            foreach (var rank in Enum.GetValues<Rank>())
+            {
+                cards.Add(new Card(rank, suit));
+            }
+        }
+
+        return cards.OrderBy(_ => Rng.Next());
+    }
+
+    public Card Draw()
+    {
+        if (_cards.Count == 0)
+        {
+            _cards = new Stack<Card>(CreateShuffledDeck().Reverse());
+        }
+
+        return _cards.Pop();
+    }
+}

--- a/TsDiscordBot.Tests/BlackJackGameTests.cs
+++ b/TsDiscordBot.Tests/BlackJackGameTests.cs
@@ -1,0 +1,82 @@
+using TsDiscordBot.Core.Game.BlackJack;
+using Xunit;
+
+namespace TsDiscordBot.Tests;
+
+public class BlackJackGameTests
+{
+    [Fact]
+    public void Hit_Busts_PlayerLoses()
+    {
+        var deck = new Deck(new[]
+        {
+            new Card(Rank.Ten, Suit.Hearts),
+            new Card(Rank.Five, Suit.Spades),
+            new Card(Rank.Nine, Suit.Clubs),
+            new Card(Rank.Six, Suit.Hearts),
+            new Card(Rank.Eight, Suit.Diamonds)
+        });
+        var game = new BlackJackGame(10, deck);
+        game.Hit();
+
+        Assert.True(game.IsFinished);
+        Assert.Equal(GameOutcome.DealerWin, game.Result!.Outcome);
+        Assert.Equal(0, game.Result.Payout);
+    }
+
+    [Fact]
+    public void Stand_PlayerHigherScore_Wins()
+    {
+        var deck = new Deck(new[]
+        {
+            new Card(Rank.Ten, Suit.Hearts),
+            new Card(Rank.Nine, Suit.Spades),
+            new Card(Rank.Nine, Suit.Clubs),
+            new Card(Rank.Six, Suit.Clubs),
+            new Card(Rank.Two, Suit.Hearts)
+        });
+        var game = new BlackJackGame(10, deck);
+        game.Stand();
+
+        Assert.True(game.IsFinished);
+        Assert.Equal(GameOutcome.PlayerWin, game.Result!.Outcome);
+        Assert.Equal(20, game.Result.Payout);
+    }
+
+    [Fact]
+    public void DoubleDown_Win_PayoutQuadrupled()
+    {
+        var deck = new Deck(new[]
+        {
+            new Card(Rank.Five, Suit.Hearts),
+            new Card(Rank.Nine, Suit.Spades),
+            new Card(Rank.Six, Suit.Clubs),
+            new Card(Rank.Nine, Suit.Hearts),
+            new Card(Rank.Ten, Suit.Diamonds)
+        });
+        var game = new BlackJackGame(10, deck);
+        game.DoubleDown();
+
+        Assert.True(game.IsFinished);
+        Assert.Equal(GameOutcome.PlayerWin, game.Result!.Outcome);
+        Assert.Equal(40, game.Result.Payout);
+    }
+
+    [Fact]
+    public void Surrender_PlayerLosesWithoutPayout()
+    {
+        var deck = new Deck(new[]
+        {
+            new Card(Rank.Ten, Suit.Hearts),
+            new Card(Rank.Nine, Suit.Spades),
+            new Card(Rank.Nine, Suit.Clubs),
+            new Card(Rank.Six, Suit.Clubs)
+        });
+        var game = new BlackJackGame(10, deck);
+        game.Surrender();
+
+        Assert.True(game.IsFinished);
+        Assert.Equal(GameOutcome.DealerWin, game.Result!.Outcome);
+        Assert.Equal(0, game.Result.Payout);
+    }
+}


### PR DESCRIPTION
## Summary
- implement BlackJack game engine with card, deck, and game management
- support betting, hitting, surrendering, and double down actions with payouts
- add tests for blackjack game scenarios

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68c6a01e69b4832d8cc5a64202a81509