### PR TITLE
Add amuse command parser with blackjack handler

### DIFF
--- a/TsDiscordBot.Core/Amuse/AmuseChannel.cs
+++ b/TsDiscordBot.Core/Amuse/AmuseChannel.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace TsDiscordBot.Core.Amuse;
+
+public class AmuseChannel
+{
+    public const string TableName = "amuse_channel";
+
+    public int Id { get; set; }
+    public ulong GuildId { get; set; }
+    public ulong ChannelId { get; set; }
+    public DateTime EnabledAtUtc { get; set; }
+}

--- a/TsDiscordBot.Core/Amuse/AmuseCommandModule.cs
+++ b/TsDiscordBot.Core/Amuse/AmuseCommandModule.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Linq;
+using Discord;
+using Discord.Interactions;
+using TsDiscordBot.Core.Services;
+
+namespace TsDiscordBot.Core.Amuse;
+
+public class AmuseCommandModule : InteractionModuleBase<SocketInteractionContext>
+{
+    private readonly DatabaseService _databaseService;
+
+    public AmuseCommandModule(DatabaseService databaseService)
+    {
+        _databaseService = databaseService;
+    }
+
+    [SlashCommand("amuse-enable", "このチャンネルでamuseコマンドを有効にします。")]
+    [RequireUserPermission(GuildPermission.Administrator)]
+    public async Task EnableAsync()
+    {
+        var guildId = Context.Guild.Id;
+        var channelId = Context.Channel.Id;
+
+        var existing = _databaseService
+            .FindAll<AmuseChannel>(AmuseChannel.TableName)
+            .FirstOrDefault(x => x.GuildId == guildId && x.ChannelId == channelId);
+
+        if (existing is not null)
+        {
+            await RespondAsync("このチャンネルでは既にamuseが有効だよ！");
+            return;
+        }
+
+        var data = new AmuseChannel
+        {
+            GuildId = guildId,
+            ChannelId = channelId,
+            EnabledAtUtc = DateTime.UtcNow
+        };
+
+        _databaseService.Insert(AmuseChannel.TableName, data);
+        await RespondAsync("amuseをこのチャンネルで有効にしたよ！");
+    }
+
+    [SlashCommand("amuse-disable", "このチャンネルでamuseコマンドを無効にします。")]
+    [RequireUserPermission(GuildPermission.Administrator)]
+    public async Task DisableAsync()
+    {
+        var guildId = Context.Guild.Id;
+        var channelId = Context.Channel.Id;
+
+        var existing = _databaseService
+            .FindAll<AmuseChannel>(AmuseChannel.TableName)
+            .FirstOrDefault(x => x.GuildId == guildId && x.ChannelId == channelId);
+
+        if (existing is null)
+        {
+            await RespondAsync("このチャンネルではamuseは有効になっていないよ！");
+            return;
+        }
+
+        _databaseService.Delete(AmuseChannel.TableName, existing.Id);
+        await RespondAsync("amuseを無効にしたよ！");
+    }
+}

--- a/TsDiscordBot.Core/Amuse/AmuseCommandParser.cs
+++ b/TsDiscordBot.Core/Amuse/AmuseCommandParser.cs
@@ -1,0 +1,28 @@
+using System;
+
+namespace TsDiscordBot.Core.Amuse;
+
+public class AmuseCommandParser : IAmuseCommandParser
+{
+    public IAmuseService? Parse(string content)
+    {
+        content = content.Trim();
+        if (!content.StartsWith("tmg", StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        var parts = content.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length >= 2 && parts[1].Equals("bj", StringComparison.OrdinalIgnoreCase))
+        {
+            int bet = 0;
+            if (parts.Length >= 3 && int.TryParse(parts[2], out var parsed))
+            {
+                bet = parsed;
+            }
+            return new PlayBlackJackService(bet);
+        }
+
+        return null;
+    }
+}

--- a/TsDiscordBot.Core/Amuse/AmuseMessageService.cs
+++ b/TsDiscordBot.Core/Amuse/AmuseMessageService.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Linq;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using TsDiscordBot.Core.Framework;
+using TsDiscordBot.Core.Services;
+
+namespace TsDiscordBot.Core.Amuse;
+
+public class AmuseMessageService : IHostedService
+{
+    private readonly IMessageReceiver _client;
+    private readonly ILogger<AmuseMessageService> _logger;
+    private readonly IAmuseCommandParser _parser;
+    private readonly DatabaseService _databaseService;
+    private IDisposable? _subscription;
+
+    public AmuseMessageService(IMessageReceiver client, ILogger<AmuseMessageService> logger, IAmuseCommandParser parser, DatabaseService databaseService)
+    {
+        _client = client;
+        _logger = logger;
+        _parser = parser;
+        _databaseService = databaseService;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        _subscription = _client.OnReceivedSubscribe(OnMessageReceivedAsync, nameof(AmuseMessageService));
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        _subscription?.Dispose();
+        return Task.CompletedTask;
+    }
+
+    private async Task OnMessageReceivedAsync(IMessageData message)
+    {
+        if (message.IsDeleted || message.IsBot)
+        {
+            return;
+        }
+
+        try
+        {
+            var enabled = _databaseService
+                .FindAll<AmuseChannel>(AmuseChannel.TableName)
+                .Any(x => x.GuildId == message.GuildId && x.ChannelId == message.ChannelId);
+
+            if (!enabled)
+            {
+                return;
+            }
+
+            var service = _parser.Parse(message.Content);
+            if (service is null)
+            {
+                return;
+            }
+
+            await service.ExecuteAsync(message);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Failed to handle amuse command.");
+        }
+    }
+}

--- a/TsDiscordBot.Core/Amuse/IAmuseCommandParser.cs
+++ b/TsDiscordBot.Core/Amuse/IAmuseCommandParser.cs
@@ -1,0 +1,6 @@
+namespace TsDiscordBot.Core.Amuse;
+
+public interface IAmuseCommandParser
+{
+    IAmuseService? Parse(string content);
+}

--- a/TsDiscordBot.Core/Amuse/IAmuseService.cs
+++ b/TsDiscordBot.Core/Amuse/IAmuseService.cs
@@ -1,0 +1,8 @@
+using TsDiscordBot.Core.Framework;
+
+namespace TsDiscordBot.Core.Amuse;
+
+public interface IAmuseService
+{
+    Task ExecuteAsync(IMessageData message);
+}

--- a/TsDiscordBot.Core/Amuse/PlayBlackJackService.cs
+++ b/TsDiscordBot.Core/Amuse/PlayBlackJackService.cs
@@ -1,0 +1,18 @@
+using TsDiscordBot.Core.Framework;
+
+namespace TsDiscordBot.Core.Amuse;
+
+public class PlayBlackJackService : IAmuseService
+{
+    private readonly int _bet;
+
+    public PlayBlackJackService(int bet)
+    {
+        _bet = bet;
+    }
+
+    public Task ExecuteAsync(IMessageData message)
+    {
+        return message.ReplyMessageAsync("test message");
+    }
+}

--- a/TsDiscordBot.Entry/Program.cs
+++ b/TsDiscordBot.Entry/Program.cs
@@ -8,6 +8,7 @@ using TsDiscordBot.Core;
 using TsDiscordBot.Core.Framework;
 using TsDiscordBot.Core.HostedService;
 using TsDiscordBot.Core.Services;
+using TsDiscordBot.Core.Amuse;
 
 // logging
 Envs.LogEnvironmentVariables();
@@ -49,6 +50,7 @@ using IHost host = Host.CreateDefaultBuilder(args)
         services.AddSingleton<MessageReceiverHub>();
         services.AddSingleton<IMessageReceiver>(sp => sp.GetRequiredService<MessageReceiverHub>());
         services.AddSingleton<IHostedService>(sp => sp.GetRequiredService<MessageReceiverHub>());
+        services.AddSingleton<IAmuseCommandParser, AmuseCommandParser>();
         // Add hosted services
         services.AddHostedService<InteractionHandlingService>();
         services.AddHostedService<DiscordStartupService>();
@@ -64,6 +66,7 @@ using IHost host = Host.CreateDefaultBuilder(args)
         services.AddHostedService<ImageReviseService>();
         services.AddHostedService<AutoDeleteService>();
         services.AddHostedService<BeRealService>();
+        services.AddHostedService<AmuseMessageService>();
         services.AddHostedService<InviteTrackingService>();
     })
     .Build();


### PR DESCRIPTION
## Summary
- add slash commands to enable/disable amuse per channel and persist config
- parse `tmg bj` messages into a blackjack service that replies with a placeholder
- handle amusement messages in enabled channels via hosted service

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c6b4bc06bc832d91e4d05b0ca2dc6d