### PR TITLE
Add virtual currency balance command to Amuse

### DIFF
--- a/TsDiscordBot.Core/Amuse/AmuseCash.cs
+++ b/TsDiscordBot.Core/Amuse/AmuseCash.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace TsDiscordBot.Core.Amuse;
+
+public class AmuseCash
+{
+    public const string TableName = "amuse_cash";
+
+    public int Id { get; set; }
+    public ulong UserId { get; set; }
+    public long Cash { get; set; }
+    public DateTime? LastEarnedAtUtc { get; set; }
+    public DateTime LastUpdatedAtUtc { get; set; }
+}
+

--- a/TsDiscordBot.Core/Amuse/AmuseCommandParser.cs
+++ b/TsDiscordBot.Core/Amuse/AmuseCommandParser.cs
@@ -1,9 +1,17 @@
 using System;
+using TsDiscordBot.Core.Services;
 
 namespace TsDiscordBot.Core.Amuse;
 
 public class AmuseCommandParser : IAmuseCommandParser
 {
+    private readonly DatabaseService _databaseService;
+
+    public AmuseCommandParser(DatabaseService databaseService)
+    {
+        _databaseService = databaseService;
+    }
+
     public IAmuseService? Parse(string content)
     {
         content = content.Trim();
@@ -13,14 +21,23 @@ public class AmuseCommandParser : IAmuseCommandParser
         }
 
         var parts = content.Split(' ', StringSplitOptions.RemoveEmptyEntries);
-        if (parts.Length >= 2 && parts[1].Equals("bj", StringComparison.OrdinalIgnoreCase))
+        if (parts.Length >= 2)
         {
-            int bet = 0;
-            if (parts.Length >= 3 && int.TryParse(parts[2], out var parsed))
+            if (parts[1].Equals("bj", StringComparison.OrdinalIgnoreCase))
             {
-                bet = parsed;
+                int bet = 0;
+                if (parts.Length >= 3 && int.TryParse(parts[2], out var parsed))
+                {
+                    bet = parsed;
+                }
+                return new PlayBlackJackService(bet);
             }
-            return new PlayBlackJackService(bet);
+
+            if (parts[1].Equals("cash", StringComparison.OrdinalIgnoreCase) ||
+                parts[1].Equals("money", StringComparison.OrdinalIgnoreCase))
+            {
+                return new ShowCashService(_databaseService);
+            }
         }
 
         return null;

--- a/TsDiscordBot.Core/Amuse/ShowCashService.cs
+++ b/TsDiscordBot.Core/Amuse/ShowCashService.cs
@@ -1,0 +1,26 @@
+using System.Linq;
+using TsDiscordBot.Core.Framework;
+using TsDiscordBot.Core.Services;
+
+namespace TsDiscordBot.Core.Amuse;
+
+public class ShowCashService : IAmuseService
+{
+    private readonly DatabaseService _databaseService;
+
+    public ShowCashService(DatabaseService databaseService)
+    {
+        _databaseService = databaseService;
+    }
+
+    public Task ExecuteAsync(IMessageData message)
+    {
+        var cash = _databaseService
+            .FindAll<AmuseCash>(AmuseCash.TableName)
+            .FirstOrDefault(x => x.UserId == message.AuthorId);
+
+        var amount = cash?.Cash ?? 0;
+        return message.ReplyMessageAsync($"{message.AuthorMention}さんは現在{amount}GAL円を保持しています。");
+    }
+}
+


### PR DESCRIPTION
## Summary
- add AmuseCash schema for user balances
- support `tmg cash`/`tmg money` commands to show balance
- implement ShowCashService and inject database into command parser

## Testing
- `dotnet format --include TsDiscordBot.Core/Amuse/AmuseCommandParser.cs TsDiscordBot.Core/Amuse/AmuseCash.cs TsDiscordBot.Core/Amuse/ShowCashService.cs`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c6d8c13878832d887974dd1bc68c4c