### PR TITLE
Add daily bonus command

### DIFF
--- a/TsDiscordBot.Core/Amuse/AmuseCommandParser.cs
+++ b/TsDiscordBot.Core/Amuse/AmuseCommandParser.cs
@@ -38,6 +38,11 @@ public class AmuseCommandParser : IAmuseCommandParser
             {
                 return new ShowCashService(_databaseService);
             }
+
+            if (parts[1].Equals("daily", StringComparison.OrdinalIgnoreCase))
+            {
+                return new DailyBonusService(_databaseService);
+            }
         }
 
         return null;

--- a/TsDiscordBot.Core/Amuse/DailyBonusService.cs
+++ b/TsDiscordBot.Core/Amuse/DailyBonusService.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Linq;
+using TsDiscordBot.Core.Framework;
+using TsDiscordBot.Core.Services;
+
+namespace TsDiscordBot.Core.Amuse;
+
+public class DailyBonusService : IAmuseService
+{
+    private readonly DatabaseService _databaseService;
+    private const long BonusAmount = 1000;
+
+    public DailyBonusService(DatabaseService databaseService)
+    {
+        _databaseService = databaseService;
+    }
+
+    public Task ExecuteAsync(IMessageData message)
+    {
+        var utcNow = DateTime.UtcNow;
+        var jstNow = utcNow.AddHours(9);
+
+        var cash = _databaseService
+            .FindAll<AmuseCash>(AmuseCash.TableName)
+            .FirstOrDefault(x => x.UserId == message.AuthorId);
+
+        if (cash is not null && cash.LastEarnedAtUtc.HasValue)
+        {
+            var lastJst = cash.LastEarnedAtUtc.Value.AddHours(9);
+            if (lastJst.Date == jstNow.Date)
+            {
+                var nextReset = jstNow.Date.AddDays(1);
+                var remaining = nextReset - jstNow;
+                return message.ReplyMessageAsync($"今日は既にデイリーボーナスを取得済みだよ！{(int)remaining.TotalHours}時間{remaining.Minutes}分後に取得できます。");
+            }
+        }
+
+        if (cash is null)
+        {
+            cash = new AmuseCash
+            {
+                UserId = message.AuthorId,
+                Cash = BonusAmount,
+                LastEarnedAtUtc = utcNow,
+                LastUpdatedAtUtc = utcNow
+            };
+            _databaseService.Insert(AmuseCash.TableName, cash);
+        }
+        else
+        {
+            cash.Cash += BonusAmount;
+            cash.LastEarnedAtUtc = utcNow;
+            cash.LastUpdatedAtUtc = utcNow;
+            _databaseService.Update(AmuseCash.TableName, cash);
+        }
+
+        return message.ReplyMessageAsync($"{message.AuthorMention}さんにデイリーボーナス{BonusAmount}GALを付与したよ！");
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `tmg daily` command for amuse channels to give 1000 GAL once per JST day
- store claim timestamp and prevent multiple claims until next JST midnight

## Testing
- `dotnet format --include TsDiscordBot.Core/Amuse/AmuseCommandParser.cs TsDiscordBot.Core/Amuse/DailyBonusService.cs --verbosity diagnostic`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68c6e5177e28832d8f9519c11c266c7d