### PR TITLE
Prevent concurrent Blackjack sessions with timeout

### DIFF
--- a/TsDiscordBot.Core/Amuse/AmusePlay.cs
+++ b/TsDiscordBot.Core/Amuse/AmusePlay.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace TsDiscordBot.Core.Amuse;
+
+public class AmusePlay
+{
+    public const string TableName = "amuse_play";
+
+    public int Id { get; set; }
+    public ulong UserId { get; set; }
+    public DateTime CreatedAtUtc { get; set; }
+    public string GameKind { get; set; } = string.Empty;
+    public ulong MessageId { get; set; }
+}
+


### PR DESCRIPTION
## Summary
- add `AmusePlay` model to track ongoing amusement games
- block starting a Blackjack game if the user already has one active
- clean up stale game sessions after 5 minutes and track message id

## Testing
- `dotnet format --include TsDiscordBot.Core/Amuse/AmusePlay.cs TsDiscordBot.Core/Amuse/PlayBlackJackService.cs --verbosity diagnostic`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c6e98cb2f4832db7816316e92d22c8