### PR TITLE
Use database start flag for BlackJack games

### DIFF
--- a/TsDiscordBot.Core/Amuse/AmusePlay.cs
+++ b/TsDiscordBot.Core/Amuse/AmusePlay.cs
@@ -13,5 +13,6 @@ public class AmusePlay
     public ulong MessageId { get; set; }
     public ulong ChannelId { get; set; }
     public int Bet { get; set; }
+    public bool Started { get; set; }
 }
 

--- a/TsDiscordBot.Core/Amuse/PlayBlackJackService.cs
+++ b/TsDiscordBot.Core/Amuse/PlayBlackJackService.cs
@@ -76,7 +76,8 @@ public class PlayBlackJackService(int bet, DatabaseService databaseService) : IA
             CreatedAtUtc = DateTime.UtcNow,
             GameKind = GameKind,
             ChannelId = message.ChannelId,
-            Bet = bet
+            Bet = bet,
+            Started = false
         };
         _databaseService.Insert(AmusePlay.TableName, play);
 

--- a/TsDiscordBot.Core/HostedService/GameBackgroundService.cs
+++ b/TsDiscordBot.Core/HostedService/GameBackgroundService.cs
@@ -46,7 +46,7 @@ public class GameBackgroundService(DiscordSocketClient client, ILogger<GameBackg
 
     private async Task ProcessBlackJackGames(AmusePlay[] amusePlays)
     {
-        foreach (var play in amusePlays.Where(x=>x.GameKind == "BJ"))
+        foreach (var play in amusePlays.Where(x => x.GameKind == "BJ" && !x.Started))
         {
             if (_games.ContainsKey(play.MessageId))
             {
@@ -63,13 +63,10 @@ public class GameBackgroundService(DiscordSocketClient client, ILogger<GameBackg
                 continue;
             }
 
-            if (userMessage.Content != "ブラックジャックのゲームを開始します。")
-            {
-                continue;
-            }
-
             var game = new BlackJackGame(play.Bet);
             _games[play.MessageId] = new GameSession(play, game);
+            play.Started = true;
+            _databaseService.Update(AmusePlay.TableName, play);
             await UpdateMessageAsync(userMessage, game, play, false);
         }
     }


### PR DESCRIPTION
## Summary
- add `Started` flag to `AmusePlay`
- initialize start flag when creating BlackJack plays
- drive BlackJack game startup via DB flag instead of message content

## Testing
- `dotnet format --include TsDiscordBot.Core/Amuse/AmusePlay.cs TsDiscordBot.Core/Amuse/PlayBlackJackService.cs TsDiscordBot.Core/HostedService/GameBackgroundService.cs --verbosity diagnostic`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c6f9407494832db68df67cc5da4ac8