### PR TITLE
Add animated dice duel game

### DIFF
--- a/TsDiscordBot.Core/Amuse/AmuseCommandParser.cs
+++ b/TsDiscordBot.Core/Amuse/AmuseCommandParser.cs
@@ -33,6 +33,16 @@ public class AmuseCommandParser : IAmuseCommandParser
                 return new PlayBlackJackService(bet, _databaseService);
             }
 
+            if (parts[1].Equals("dice", StringComparison.OrdinalIgnoreCase))
+            {
+                int bet = 0;
+                if (parts.Length >= 3 && int.TryParse(parts[2], out var parsed))
+                {
+                    bet = parsed;
+                }
+                return new PlayDiceService(bet, _databaseService);
+            }
+
             if (parts[1].Equals("cash", StringComparison.OrdinalIgnoreCase) ||
                 parts[1].Equals("money", StringComparison.OrdinalIgnoreCase))
             {

--- a/TsDiscordBot.Core/Amuse/PlayDiceService.cs
+++ b/TsDiscordBot.Core/Amuse/PlayDiceService.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Linq;
+using TsDiscordBot.Core.Framework;
+using TsDiscordBot.Core.Services;
+
+namespace TsDiscordBot.Core.Amuse;
+
+public class PlayDiceService(int bet, DatabaseService databaseService) : IAmuseService
+{
+    private const string GameKind = "DI";
+    private readonly int _bet = bet;
+    private readonly DatabaseService _databaseService = databaseService;
+
+    public async Task ExecuteAsync(IMessageData message)
+    {
+        var existing = _databaseService
+            .FindAll<AmusePlay>(AmusePlay.TableName)
+            .FirstOrDefault(x => x.UserId == message.AuthorId && x.GameKind == GameKind);
+
+        if (existing is not null)
+        {
+            var elapsed = DateTime.UtcNow - existing.CreatedAtUtc;
+            if (elapsed < TimeSpan.FromMinutes(5))
+            {
+                await message.ReplyMessageAsync("現在サイコロ勝負をプレイ中です。5分後に再試行してください。");
+                return;
+            }
+
+            _databaseService.Delete(AmusePlay.TableName, existing.Id);
+        }
+
+        var cash = _databaseService
+            .FindAll<AmuseCash>(AmuseCash.TableName)
+            .FirstOrDefault(x => x.UserId == message.AuthorId);
+
+        if (cash is null)
+        {
+            cash = new AmuseCash
+            {
+                UserId = message.AuthorId,
+                Cash = 0,
+                LastUpdatedAtUtc = DateTime.UtcNow
+            };
+            _databaseService.Insert(AmuseCash.TableName, cash);
+        }
+
+        var currentCash = cash.Cash;
+
+        var bet = _bet;
+        if (currentCash <= 0)
+        {
+            bet = 100;
+            currentCash -= bet;
+        }
+        else
+        {
+            if (bet <= 0)
+            {
+                bet = currentCash < 100 ? (int)currentCash : 100;
+            }
+            else if (bet > currentCash)
+            {
+                bet = (int)currentCash;
+            }
+
+            currentCash -= bet;
+        }
+
+        cash.Cash = currentCash;
+        cash.LastUpdatedAtUtc = DateTime.UtcNow;
+        _databaseService.Update(AmuseCash.TableName, cash);
+
+        var play = new AmusePlay
+        {
+            UserId = message.AuthorId,
+            CreatedAtUtc = DateTime.UtcNow,
+            GameKind = GameKind,
+            ChannelId = message.ChannelId,
+            Bet = bet,
+            Started = false
+        };
+        _databaseService.Insert(AmusePlay.TableName, play);
+
+        var reply = await message.ReplyMessageAsync("サイコロ勝負のゲームを開始します。");
+
+        if (reply is not null)
+        {
+            play.MessageId = reply.Id;
+            _databaseService.Update(AmusePlay.TableName, play);
+        }
+    }
+}
+

--- a/TsDiscordBot.Core/Game/Dice/DiceGame.cs
+++ b/TsDiscordBot.Core/Game/Dice/DiceGame.cs
@@ -1,0 +1,50 @@
+using System;
+
+namespace TsDiscordBot.Core.Game.Dice;
+
+public enum DiceOutcome
+{
+    PlayerWin,
+    DealerWin,
+    Push
+}
+
+public sealed record DiceResult(DiceOutcome Outcome, int Payout, int DealerRoll, int PlayerRoll);
+
+public class DiceGame
+{
+    private readonly Random _random;
+
+    public int Bet { get; }
+    public DiceResult Result { get; }
+
+    public DiceGame(int bet, int? dealerRoll = null, int? playerRoll = null, Random? random = null)
+    {
+        Bet = bet;
+        _random = random ?? new Random();
+        var dealer = dealerRoll ?? _random.Next(1, 7);
+        var player = playerRoll ?? _random.Next(1, 7);
+        var outcome = DetermineOutcome(dealer, player);
+        var payout = outcome switch
+        {
+            DiceOutcome.PlayerWin => Bet * 2,
+            DiceOutcome.Push => Bet,
+            _ => 0
+        };
+        Result = new DiceResult(outcome, payout, dealer, player);
+    }
+
+    private static DiceOutcome DetermineOutcome(int dealer, int player)
+    {
+        if (player > dealer)
+        {
+            return DiceOutcome.PlayerWin;
+        }
+        if (player < dealer)
+        {
+            return DiceOutcome.DealerWin;
+        }
+        return DiceOutcome.Push;
+    }
+}
+

--- a/TsDiscordBot.Core/HostedService/GameBackgroundService.cs
+++ b/TsDiscordBot.Core/HostedService/GameBackgroundService.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using TsDiscordBot.Core.Amuse;
 using TsDiscordBot.Core.Game.BlackJack;
+using TsDiscordBot.Core.Game.Dice;
 using TsDiscordBot.Core.Services;
 
 namespace TsDiscordBot.Core.HostedService;
@@ -15,8 +16,10 @@ public class GameBackgroundService(DiscordSocketClient client, ILogger<GameBackg
     private readonly ILogger<GameBackgroundService> _logger = logger;
     private readonly DatabaseService _databaseService = databaseService;
     private readonly ConcurrentDictionary<ulong, GameSession> _games = new();
+    private readonly ConcurrentDictionary<ulong, DiceSession> _diceGames = new();
 
     private record GameSession(AmusePlay Play, BlackJackGame Game);
+    private record DiceSession(AmusePlay Play, DiceGame Game, int Step, DateTime LastUpdate);
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
@@ -31,6 +34,7 @@ public class GameBackgroundService(DiscordSocketClient client, ILogger<GameBackg
                     .ToArray();
 
                 await ProcessBlackJackGames(plays);
+                await ProcessDiceGames(plays);
 
             }
             catch (Exception e)
@@ -68,6 +72,66 @@ public class GameBackgroundService(DiscordSocketClient client, ILogger<GameBackg
             play.Started = true;
             _databaseService.Update(AmusePlay.TableName, play);
             await UpdateMessageAsync(userMessage, game, play, false);
+        }
+    }
+
+    private async Task ProcessDiceGames(AmusePlay[] amusePlays)
+    {
+        foreach (var play in amusePlays.Where(x => x.GameKind == "DI"))
+        {
+            if (!_diceGames.TryGetValue(play.MessageId, out var session))
+            {
+                if (play.Started)
+                {
+                    continue;
+                }
+
+                var game = new DiceGame(play.Bet);
+                session = new DiceSession(play, game, 0, DateTime.UtcNow);
+                _diceGames[play.MessageId] = session;
+                play.Started = true;
+                _databaseService.Update(AmusePlay.TableName, play);
+                continue;
+            }
+
+            if (DateTime.UtcNow - session.LastUpdate < TimeSpan.FromSeconds(1))
+            {
+                continue;
+            }
+
+            if (_client.GetChannel(session.Play.ChannelId) is not IMessageChannel channel)
+            {
+                continue;
+            }
+
+            if (await channel.GetMessageAsync(session.Play.MessageId) is not IUserMessage userMessage)
+            {
+                continue;
+            }
+
+            if (session.Step == 0)
+            {
+                await UpdateDiceMessageAsync(userMessage, session.Game, session.Play, false);
+                _diceGames[play.MessageId] = session with { Step = 1, LastUpdate = DateTime.UtcNow };
+            }
+            else if (session.Step == 1)
+            {
+                await UpdateDiceMessageAsync(userMessage, session.Game, session.Play, true);
+
+                var result = session.Game.Result;
+                var cash = _databaseService
+                    .FindAll<AmuseCash>(AmuseCash.TableName)
+                    .FirstOrDefault(x => x.UserId == session.Play.UserId);
+                if (cash is not null)
+                {
+                    cash.Cash += result.Payout;
+                    cash.LastUpdatedAtUtc = DateTime.UtcNow;
+                    _databaseService.Update(AmuseCash.TableName, cash);
+                }
+
+                _databaseService.Delete(AmusePlay.TableName, session.Play.Id);
+                _diceGames.TryRemove(session.Play.MessageId, out _);
+            }
         }
     }
 
@@ -239,6 +303,50 @@ public class GameBackgroundService(DiscordSocketClient client, ILogger<GameBackg
         {
             msg.Content = builder.ToString();
             msg.Components = components.Build();
+        });
+    }
+
+    private static readonly string[] DiceCharacters =
+    {
+        "\u2680",
+        "\u2681",
+        "\u2682",
+        "\u2683",
+        "\u2684",
+        "\u2685"
+    };
+
+    private static async Task UpdateDiceMessageAsync(IUserMessage message, DiceGame game, AmusePlay play, bool revealPlayer)
+    {
+        var builder = new System.Text.StringBuilder();
+        builder.AppendLine($"<@{play.UserId}> さん、");
+        builder.AppendLine($"{play.Bet}GAL円 賭けて勝負だよ！！");
+        builder.AppendLine($"- つむぎ: {DiceCharacters[game.Result.DealerRoll - 1]}[{game.Result.DealerRoll}]");
+
+        if (revealPlayer)
+        {
+            builder.AppendLine($"- あなた: {DiceCharacters[game.Result.PlayerRoll - 1]}[{game.Result.PlayerRoll}]");
+            var outcome = game.Result.Outcome switch
+            {
+                DiceOutcome.PlayerWin => "勝利",
+                DiceOutcome.DealerWin => "敗北",
+                _ => "引き分け"
+            };
+            builder.AppendLine($"結果: {outcome}！");
+            if (game.Result.Outcome == DiceOutcome.PlayerWin)
+            {
+                builder.AppendLine($"{game.Result.Payout}GAL円ゲット！");
+            }
+        }
+        else
+        {
+            builder.AppendLine("- あなた: ??");
+        }
+
+        await message.ModifyAsync(msg =>
+        {
+            msg.Content = builder.ToString();
+            msg.Components = new ComponentBuilder().Build();
         });
     }
 }

--- a/TsDiscordBot.Tests/DiceGameTests.cs
+++ b/TsDiscordBot.Tests/DiceGameTests.cs
@@ -1,0 +1,32 @@
+using TsDiscordBot.Core.Game.Dice;
+using Xunit;
+
+namespace TsDiscordBot.Tests;
+
+public class DiceGameTests
+{
+    [Fact]
+    public void PlayerHigherRoll_Wins()
+    {
+        var game = new DiceGame(10, dealerRoll: 2, playerRoll: 5);
+        Assert.Equal(DiceOutcome.PlayerWin, game.Result.Outcome);
+        Assert.Equal(20, game.Result.Payout);
+    }
+
+    [Fact]
+    public void DealerHigherRoll_PlayerLoses()
+    {
+        var game = new DiceGame(10, dealerRoll: 6, playerRoll: 1);
+        Assert.Equal(DiceOutcome.DealerWin, game.Result.Outcome);
+        Assert.Equal(0, game.Result.Payout);
+    }
+
+    [Fact]
+    public void SameRoll_Push()
+    {
+        var game = new DiceGame(10, dealerRoll: 3, playerRoll: 3);
+        Assert.Equal(DiceOutcome.Push, game.Result.Outcome);
+        Assert.Equal(10, game.Result.Payout);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `/tmg dice` amuse command to start a dice duel
- implement `DiceGame` with payout logic and session handling in `GameBackgroundService`
- cover dice game outcomes with unit tests

## Testing
- `dotnet format --include TsDiscordBot.Core/Amuse/AmuseCommandParser.cs TsDiscordBot.Core/HostedService/GameBackgroundService.cs TsDiscordBot.Core/Amuse/PlayDiceService.cs TsDiscordBot.Core/Game/Dice/DiceGame.cs TsDiscordBot.Tests/DiceGameTests.cs -v diag`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68c6ffae5678832da97b5d1d8c3bc74e