### PR TITLE
feat(amuse): add all bet option

### DIFF
--- a/TsDiscordBot.Core/Amuse/AmuseCommandParser.cs
+++ b/TsDiscordBot.Core/Amuse/AmuseCommandParser.cs
@@ -25,21 +25,13 @@ public class AmuseCommandParser : IAmuseCommandParser
         {
             if (parts[1].Equals("bj", StringComparison.OrdinalIgnoreCase))
             {
-                int bet = 0;
-                if (parts.Length >= 3 && int.TryParse(parts[2], out var parsed))
-                {
-                    bet = parsed;
-                }
+                var bet = ParseBet(parts);
                 return new PlayBlackJackService(bet, _databaseService);
             }
 
             if (parts[1].Equals("dice", StringComparison.OrdinalIgnoreCase))
             {
-                int bet = 0;
-                if (parts.Length >= 3 && int.TryParse(parts[2], out var parsed))
-                {
-                    bet = parsed;
-                }
+                var bet = ParseBet(parts);
                 return new PlayDiceService(bet, _databaseService);
             }
 
@@ -66,5 +58,23 @@ public class AmuseCommandParser : IAmuseCommandParser
         }
 
         return null;
+    }
+
+    private static int ParseBet(string[] parts)
+    {
+        if (parts.Length >= 3)
+        {
+            if (parts[2].Equals("all", StringComparison.OrdinalIgnoreCase))
+            {
+                return int.MaxValue;
+            }
+
+            if (int.TryParse(parts[2], out var parsed))
+            {
+                return parsed;
+            }
+        }
+
+        return 0;
     }
 }

--- a/TsDiscordBot.Core/Amuse/PlayGameServiceBase.cs
+++ b/TsDiscordBot.Core/Amuse/PlayGameServiceBase.cs
@@ -57,7 +57,11 @@ public abstract class PlayGameServiceBase(int bet, DatabaseService databaseServi
         }
         else
         {
-            if (bet <= 0)
+            if (bet == int.MaxValue)
+            {
+                bet = currentCash > int.MaxValue ? int.MaxValue : (int)currentCash;
+            }
+            else if (bet <= 0)
             {
                 bet = currentCash < 100 ? (int)currentCash : 100;
             }


### PR DESCRIPTION
## Summary
- allow `all` bet option for BlackJack and Dice games
- handle betting entire balance or borrowing when broke

## Testing
- `dotnet format --include TsDiscordBot.Core/Amuse/AmuseCommandParser.cs TsDiscordBot.Core/Amuse/PlayGameServiceBase.cs`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68c7696ddecc832da9c9c0518b9ca8a8