### PR TITLE
Track user win stats per game

### DIFF
--- a/TsDiscordBot.Core/Amuse/AmuseGameRecord.cs
+++ b/TsDiscordBot.Core/Amuse/AmuseGameRecord.cs
@@ -1,0 +1,13 @@
+namespace TsDiscordBot.Core.Amuse;
+
+public class AmuseGameRecord
+{
+    public const string TableName = "amuse_game_record";
+
+    public int Id { get; set; }
+    public ulong UserId { get; set; }
+    public string GameKind { get; set; } = string.Empty;
+    public int TotalPlays { get; set; }
+    public int WinCount { get; set; }
+}
+


### PR DESCRIPTION
## Summary
- add AmuseGameRecord model to store per-user game totals and wins
- record blackjack and dice outcomes into new stats table

## Testing
- `dotnet format --include TsDiscordBot.Core/Amuse/AmuseGameRecord.cs TsDiscordBot.Core/HostedService/Amuse/BlackJackBackgroundLoigic.cs TsDiscordBot.Core/HostedService/Amuse/DiceBackgroundLogic.cs --verbosity normal`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c76aa8902c832d94fef1ba90ac0e3c