### PR TITLE
Add win rate commands for amuse games

### DIFF
--- a/TsDiscordBot.Core/Amuse/AmuseCommandParser.cs
+++ b/TsDiscordBot.Core/Amuse/AmuseCommandParser.cs
@@ -48,12 +48,30 @@ public class AmuseCommandParser : IAmuseCommandParser
 
             if (parts[1].Equals("top", StringComparison.OrdinalIgnoreCase))
             {
+                if (parts.Length >= 3)
+                {
+                    if (parts[2].Equals("bj", StringComparison.OrdinalIgnoreCase))
+                    {
+                        return new ShowTopWinRateService("BJ", "ブラックジャック", _databaseService);
+                    }
+
+                    if (parts[2].Equals("dice", StringComparison.OrdinalIgnoreCase))
+                    {
+                        return new ShowTopWinRateService("DI", "サイコロゲーム", _databaseService);
+                    }
+                }
+
                 return new ShowTopCashService(_databaseService);
             }
 
             if (parts[1].Equals("rank", StringComparison.OrdinalIgnoreCase))
             {
                 return new ShowRankService(_databaseService);
+            }
+
+            if (parts[1].Equals("winrate", StringComparison.OrdinalIgnoreCase))
+            {
+                return new ShowWinRateService(_databaseService);
             }
         }
 

--- a/TsDiscordBot.Core/Amuse/ShowTopWinRateService.cs
+++ b/TsDiscordBot.Core/Amuse/ShowTopWinRateService.cs
@@ -1,0 +1,48 @@
+using System.Linq;
+using System.Text;
+using TsDiscordBot.Core.Framework;
+using TsDiscordBot.Core.Services;
+
+namespace TsDiscordBot.Core.Amuse;
+
+public class ShowTopWinRateService : IAmuseService
+{
+    private readonly DatabaseService _databaseService;
+    private readonly string _gameKind;
+    private readonly string _gameName;
+
+    public ShowTopWinRateService(string gameKind, string gameName, DatabaseService databaseService)
+    {
+        _gameKind = gameKind;
+        _gameName = gameName;
+        _databaseService = databaseService;
+    }
+
+    public Task ExecuteAsync(IMessageData message)
+    {
+        var records = _databaseService
+            .FindAll<AmuseGameRecord>(AmuseGameRecord.TableName)
+            .Where(x => x.GameKind == _gameKind && x.TotalPlays > 0)
+            .OrderByDescending(x => (double)x.WinCount / x.TotalPlays)
+            .ThenByDescending(x => x.TotalPlays)
+            .Take(10)
+            .ToArray();
+
+        if (records.Length == 0)
+        {
+            return message.ReplyMessageAsync($"まだ誰も{_gameName}をプレイしていないよ！");
+        }
+
+        var sb = new StringBuilder();
+        for (var i = 0; i < records.Length; i++)
+        {
+            var r = records[i];
+            var rate = r.WinCount * 100.0 / r.TotalPlays;
+            var rank = i + 1;
+            sb.AppendLine($"{rank}. <@{r.UserId}>　{rate:0.##}% ({r.WinCount}/{r.TotalPlays})");
+        }
+
+        return message.ReplyMessageAsync(sb.ToString().TrimEnd());
+    }
+}
+

--- a/TsDiscordBot.Core/Amuse/ShowWinRateService.cs
+++ b/TsDiscordBot.Core/Amuse/ShowWinRateService.cs
@@ -1,0 +1,47 @@
+using System.Linq;
+using System.Text;
+using TsDiscordBot.Core.Framework;
+using TsDiscordBot.Core.Services;
+
+namespace TsDiscordBot.Core.Amuse;
+
+public class ShowWinRateService : IAmuseService
+{
+    private readonly DatabaseService _databaseService;
+
+    public ShowWinRateService(DatabaseService databaseService)
+    {
+        _databaseService = databaseService;
+    }
+
+    public Task ExecuteAsync(IMessageData message)
+    {
+        var records = _databaseService
+            .FindAll<AmuseGameRecord>(AmuseGameRecord.TableName)
+            .Where(x => x.UserId == message.AuthorId)
+            .ToArray();
+
+        if (records.Length == 0)
+        {
+            return message.ReplyMessageAsync("あなたはまだゲームをプレイしていないよ！");
+        }
+
+        var sb = new StringBuilder();
+        foreach (var record in records)
+        {
+            var rate = record.TotalPlays > 0
+                ? record.WinCount * 100.0 / record.TotalPlays
+                : 0;
+            var gameName = record.GameKind switch
+            {
+                "BJ" => "ブラックジャック",
+                "DI" => "サイコロゲーム",
+                _ => record.GameKind
+            };
+            sb.AppendLine($"{gameName}: {rate:0.##}% ({record.WinCount}/{record.TotalPlays})");
+        }
+
+        return message.ReplyMessageAsync(sb.ToString().TrimEnd());
+    }
+}
+


### PR DESCRIPTION
## Summary
- allow users to check their own win rates across played games
- add ranking commands for Blackjack and dice win rates

## Testing
- `dotnet format --include TsDiscordBot.Core/Amuse/AmuseCommandParser.cs TsDiscordBot.Core/Amuse/ShowTopWinRateService.cs TsDiscordBot.Core/Amuse/ShowWinRateService.cs -v diag`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c76df5e02c832d85eda55d3b9ce68e