### PR TITLE
Add High and Low amusement game

### DIFF
--- a/TsDiscordBot.Core/Amuse/AmuseCommandParser.cs
+++ b/TsDiscordBot.Core/Amuse/AmuseCommandParser.cs
@@ -35,6 +35,12 @@ public class AmuseCommandParser : IAmuseCommandParser
                 return new PlayDiceService(bet, _databaseService);
             }
 
+            if (parts[1].Equals("lw", StringComparison.OrdinalIgnoreCase))
+            {
+                var bet = ParseBet(parts);
+                return new PlayHighLowService(bet, _databaseService);
+            }
+
             if (parts[1].Equals("cash", StringComparison.OrdinalIgnoreCase) ||
                 parts[1].Equals("money", StringComparison.OrdinalIgnoreCase))
             {

--- a/TsDiscordBot.Core/Amuse/PlayHighLowService.cs
+++ b/TsDiscordBot.Core/Amuse/PlayHighLowService.cs
@@ -1,0 +1,13 @@
+using TsDiscordBot.Core.Services;
+
+namespace TsDiscordBot.Core.Amuse;
+
+public class PlayHighLowService(int bet, DatabaseService databaseService)
+    : PlayGameServiceBase(bet, databaseService)
+{
+    protected override string GameKind => "HL";
+    protected override string InProgressMessage =>
+        "現在ハイ＆ローをプレイ中です。5分後に再試行してください。";
+    protected override string StartMessage => "ハイ＆ローのゲームを開始します。";
+}
+

--- a/TsDiscordBot.Core/Game/HighLow/HighLowGame.cs
+++ b/TsDiscordBot.Core/Game/HighLow/HighLowGame.cs
@@ -1,0 +1,53 @@
+using TsDiscordBot.Core.Game.BlackJack;
+
+namespace TsDiscordBot.Core.Game.HighLow;
+
+public enum GuessPrediction
+{
+    High,
+    Low
+}
+
+public sealed record GuessResult(bool Correct, Card DrawnCard, bool MaxReached);
+
+public class HighLowGame
+{
+    private readonly Deck _deck;
+
+    public int Bet { get; }
+    public Card CurrentCard { get; private set; }
+    public int Streak { get; private set; }
+    public int MaxStreak { get; } = 10;
+
+    public HighLowGame(int bet, Deck? deck = null)
+    {
+        Bet = bet;
+        _deck = deck ?? new Deck();
+        CurrentCard = _deck.Draw();
+    }
+
+    public GuessResult Guess(GuessPrediction prediction)
+    {
+        Card next;
+        do
+        {
+            next = _deck.Draw();
+        } while (next.Rank == CurrentCard.Rank);
+
+        var correct = prediction == GuessPrediction.High
+            ? next.Rank > CurrentCard.Rank
+            : next.Rank < CurrentCard.Rank;
+
+        CurrentCard = next;
+        if (correct)
+        {
+            Streak++;
+            return new GuessResult(true, next, Streak >= MaxStreak);
+        }
+
+        return new GuessResult(false, next, false);
+    }
+
+    public int CalculatePayout() => Bet * Streak;
+}
+

--- a/TsDiscordBot.Core/HostedService/Amuse/GameBackgroundService.cs
+++ b/TsDiscordBot.Core/HostedService/Amuse/GameBackgroundService.cs
@@ -22,8 +22,9 @@ public class GameBackgroundService : BackgroundService
 
         _amuseBackgroundLogics =
         [
-            new BlackJackBackgroundLogic(databaseService,logger,client),
-            new DiceBackgroundLogic(databaseService,client)
+            new BlackJackBackgroundLogic(databaseService, logger, client),
+            new DiceBackgroundLogic(databaseService, client),
+            new HighLowBackgroundLogic(databaseService, client)
         ];
     }
 
@@ -46,7 +47,7 @@ public class GameBackgroundService : BackgroundService
                     {
                         await logic.ProcessAsync(plays);
                     }
-                    catch(Exception e)
+                    catch (Exception e)
                     {
                         _logger.LogError(e, $"Failed to {logic.GetType()}.ProcessAsync");
                     }
@@ -73,7 +74,7 @@ public class GameBackgroundService : BackgroundService
             {
                 await logic.OnButtonExecutedAsync(component);
             }
-            catch(Exception e)
+            catch (Exception e)
             {
                 _logger.LogError(e, $"Failed to {logic.GetType()}.OnButtonExecutedAsync");
             }

--- a/TsDiscordBot.Core/HostedService/Amuse/HighLowBackgroundLogic.cs
+++ b/TsDiscordBot.Core/HostedService/Amuse/HighLowBackgroundLogic.cs
@@ -1,0 +1,292 @@
+using System.Collections.Concurrent;
+using System.Linq;
+using Discord;
+using Discord.WebSocket;
+using TsDiscordBot.Core.Amuse;
+using TsDiscordBot.Core.Game.HighLow;
+using TsDiscordBot.Core.Game.BlackJack;
+using TsDiscordBot.Core.Services;
+
+namespace TsDiscordBot.Core.HostedService.Amuse;
+
+public class HighLowBackgroundLogic(DatabaseService databaseService, DiscordSocketClient client) : IAmuseBackgroundLogic
+{
+    private enum SessionState
+    {
+        Guess,
+        Decision
+    }
+
+    private record HighLowSession(AmusePlay Play, HighLowGame Game, SessionState State);
+
+    private readonly ConcurrentDictionary<ulong, HighLowSession> _sessions = new();
+    private readonly DatabaseService _databaseService = databaseService;
+    private readonly DiscordSocketClient _client = client;
+
+    public async Task OnButtonExecutedAsync(SocketMessageComponent component)
+    {
+        if (!component.Data.CustomId.StartsWith("empty_hl_"))
+        {
+            return;
+        }
+
+        var parts = component.Data.CustomId.Split(':');
+        if (parts.Length != 2)
+        {
+            return;
+        }
+
+        if (!ulong.TryParse(parts[1], out var messageId))
+        {
+            return;
+        }
+
+        if (!_sessions.TryGetValue(messageId, out var session))
+        {
+            await component.RespondAsync("ゲームが見つかりません。", ephemeral: true);
+            return;
+        }
+
+        if (component.User.Id != session.Play.UserId)
+        {
+            return;
+        }
+
+        await component.DeferAsync();
+
+        if (_client.GetChannel(session.Play.ChannelId) is not IMessageChannel channel)
+        {
+            return;
+        }
+
+        if (await channel.GetMessageAsync(session.Play.MessageId) is not IUserMessage userMessage)
+        {
+            return;
+        }
+
+        switch (parts[0])
+        {
+            case "empty_hl_high":
+            case "empty_hl_low":
+                if (session.State != SessionState.Guess)
+                {
+                    return;
+                }
+
+                var prediction = parts[0] == "empty_hl_high" ? GuessPrediction.High : GuessPrediction.Low;
+                var previous = session.Game.CurrentCard;
+                var result = session.Game.Guess(prediction);
+                if (result.Correct)
+                {
+                    if (result.MaxReached)
+                    {
+                        await ShowResultAsync(userMessage, session.Play, previous, result.DrawnCard, true, false, session.Game.Streak, session.Game.CalculatePayout());
+                        FinalizeWin(session);
+                    }
+                    else
+                    {
+                        await ShowResultAsync(userMessage, session.Play, previous, result.DrawnCard, true, true, session.Game.Streak);
+                        _sessions[messageId] = session with { State = SessionState.Decision };
+                    }
+                }
+                else
+                {
+                    await ShowResultAsync(userMessage, session.Play, previous, result.DrawnCard, false, false, session.Game.Streak);
+                    FinalizeLoss(session);
+                }
+                break;
+            case "empty_hl_continue":
+                if (session.State != SessionState.Decision)
+                {
+                    return;
+                }
+
+                await ShowGuessAsync(userMessage, session.Play, session.Game);
+                _sessions[messageId] = session with { State = SessionState.Guess };
+                break;
+            case "empty_hl_stop":
+                if (session.State != SessionState.Decision)
+                {
+                    return;
+                }
+
+                await ShowStopAsync(userMessage, session.Play, session.Game);
+                FinalizeWin(session);
+                break;
+        }
+    }
+
+    public async Task ProcessAsync(AmusePlay[] amusePlays)
+    {
+        foreach (var play in amusePlays.Where(x => x.GameKind == "HL" && !x.Started))
+        {
+            if (_sessions.ContainsKey(play.MessageId))
+            {
+                continue;
+            }
+
+            if (_client.GetChannel(play.ChannelId) is not IMessageChannel channel)
+            {
+                continue;
+            }
+
+            if (await channel.GetMessageAsync(play.MessageId) is not IUserMessage userMessage)
+            {
+                continue;
+            }
+
+            var game = new HighLowGame(play.Bet);
+            _sessions[play.MessageId] = new HighLowSession(play, game, SessionState.Guess);
+            play.Started = true;
+            _databaseService.Update(AmusePlay.TableName, play);
+            await ShowGuessAsync(userMessage, play, game);
+        }
+    }
+
+    private async Task ShowGuessAsync(IUserMessage message, AmusePlay play, HighLowGame game)
+    {
+        var builder = new System.Text.StringBuilder();
+        builder.AppendLine($"<@{play.UserId}> さん、");
+        builder.AppendLine($"{play.Bet}GAL円 賭けて勝負だよ！！");
+        builder.AppendLine($"現在のカード: {FormatCard(game.CurrentCard)}");
+        builder.AppendLine($"現在の連勝数: {game.Streak}");
+        builder.AppendLine("次のカードはハイ？ロー？");
+
+        var components = new ComponentBuilder()
+            .WithButton("ハイ", $"empty_hl_high:{play.MessageId}", ButtonStyle.Primary)
+            .WithButton("ロー", $"empty_hl_low:{play.MessageId}", ButtonStyle.Primary);
+
+        await message.ModifyAsync(msg =>
+        {
+            msg.Content = builder.ToString();
+            msg.Components = components.Build();
+        });
+    }
+
+    private async Task ShowResultAsync(IUserMessage message, AmusePlay play, Card previous, Card drawn, bool correct, bool allowContinue, int streak, int? payout = null)
+    {
+        var builder = new System.Text.StringBuilder();
+        builder.AppendLine($"<@{play.UserId}> さん、");
+        builder.AppendLine($"{play.Bet}GAL円 賭けて勝負だよ！！");
+        builder.AppendLine($"前のカード: {FormatCard(previous)}");
+        builder.AppendLine($"引いたカード: {FormatCard(drawn)}");
+
+        if (correct)
+        {
+            builder.AppendLine("正解！");
+            builder.AppendLine($"現在の連勝数: {streak}");
+            if (payout.HasValue)
+            {
+                builder.AppendLine($"{payout.Value}GAL円ゲット！");
+            }
+        }
+        else
+        {
+            builder.AppendLine("不正解…あなたの負けです。");
+        }
+
+        var components = new ComponentBuilder();
+        if (correct && allowContinue)
+        {
+            builder.AppendLine("続ける？それともやめる？");
+            components.WithButton("続ける", $"empty_hl_continue:{play.MessageId}", ButtonStyle.Success)
+                      .WithButton("やめる", $"empty_hl_stop:{play.MessageId}", ButtonStyle.Danger);
+        }
+
+        await message.ModifyAsync(msg =>
+        {
+            msg.Content = builder.ToString();
+            msg.Components = components.Build();
+        });
+    }
+
+    private async Task ShowStopAsync(IUserMessage message, AmusePlay play, HighLowGame game)
+    {
+        var payout = game.CalculatePayout();
+        var builder = new System.Text.StringBuilder();
+        builder.AppendLine($"<@{play.UserId}> さん、");
+        builder.AppendLine($"{play.Bet}GAL円 賭けて勝負だよ！！");
+        builder.AppendLine($"現在のカード: {FormatCard(game.CurrentCard)}");
+        builder.AppendLine($"連勝数: {game.Streak}で終了しました。");
+        builder.AppendLine($"{payout}GAL円ゲット！");
+
+        await message.ModifyAsync(msg =>
+        {
+            msg.Content = builder.ToString();
+            msg.Components = new ComponentBuilder().Build();
+        });
+    }
+
+    private void FinalizeWin(HighLowSession session)
+    {
+        var payout = session.Game.CalculatePayout();
+        var cash = _databaseService
+            .FindAll<AmuseCash>(AmuseCash.TableName)
+            .FirstOrDefault(x => x.UserId == session.Play.UserId);
+        if (cash is not null)
+        {
+            cash.Cash += payout;
+            cash.LastUpdatedAtUtc = DateTime.UtcNow;
+            _databaseService.Update(AmuseCash.TableName, cash);
+        }
+
+        UpdateGameRecord(session.Play.UserId, session.Play.GameKind, session.Game.Streak > 0);
+        _databaseService.Delete(AmusePlay.TableName, session.Play.Id);
+        _sessions.TryRemove(session.Play.MessageId, out _);
+    }
+
+    private void FinalizeLoss(HighLowSession session)
+    {
+        UpdateGameRecord(session.Play.UserId, session.Play.GameKind, false);
+        _databaseService.Delete(AmusePlay.TableName, session.Play.Id);
+        _sessions.TryRemove(session.Play.MessageId, out _);
+    }
+
+    private void UpdateGameRecord(ulong userId, string gameKind, bool win)
+    {
+        var record = _databaseService
+            .FindAll<AmuseGameRecord>(AmuseGameRecord.TableName)
+            .FirstOrDefault(x => x.UserId == userId && x.GameKind == gameKind);
+
+        if (record is null)
+        {
+            record = new AmuseGameRecord
+            {
+                UserId = userId,
+                GameKind = gameKind,
+                TotalPlays = 0,
+                WinCount = 0
+            };
+            _databaseService.Insert(AmuseGameRecord.TableName, record);
+        }
+
+        record.TotalPlays++;
+        if (win)
+        {
+            record.WinCount++;
+        }
+
+        _databaseService.Update(AmuseGameRecord.TableName, record);
+    }
+
+    private static string FormatCard(Card c)
+    {
+        var rank = c.Rank switch
+        {
+            Rank.Ace => "A",
+            Rank.King => "K",
+            Rank.Queen => "Q",
+            Rank.Jack => "J",
+            _ => ((int)c.Rank).ToString()
+        };
+        var suit = c.Suit switch
+        {
+            Suit.Clubs => "♣",
+            Suit.Diamonds => "♦",
+            Suit.Hearts => "♥",
+            _ => "♠"
+        };
+        return rank + suit;
+    }
+}
+

--- a/TsDiscordBot.Tests/HighLowGameTests.cs
+++ b/TsDiscordBot.Tests/HighLowGameTests.cs
@@ -1,0 +1,53 @@
+using TsDiscordBot.Core.Game.BlackJack;
+using TsDiscordBot.Core.Game.HighLow;
+using Xunit;
+
+namespace TsDiscordBot.Tests;
+
+public class HighLowGameTests
+{
+    [Fact]
+    public void CorrectHighGuess_IncrementsStreak()
+    {
+        var deck = new Deck(new[]
+        {
+            new Card(Rank.Five, Suit.Clubs),
+            new Card(Rank.Seven, Suit.Clubs)
+        });
+        var game = new HighLowGame(10, deck);
+        var result = game.Guess(GuessPrediction.High);
+        Assert.True(result.Correct);
+        Assert.Equal(Rank.Seven, result.DrawnCard.Rank);
+        Assert.Equal(1, game.Streak);
+    }
+
+    [Fact]
+    public void IncorrectGuess_EndsWithoutStreak()
+    {
+        var deck = new Deck(new[]
+        {
+            new Card(Rank.Eight, Suit.Clubs),
+            new Card(Rank.Three, Suit.Clubs)
+        });
+        var game = new HighLowGame(10, deck);
+        var result = game.Guess(GuessPrediction.High);
+        Assert.False(result.Correct);
+        Assert.Equal(0, game.Streak);
+    }
+
+    [Fact]
+    public void TieIsIgnored()
+    {
+        var deck = new Deck(new[]
+        {
+            new Card(Rank.Four, Suit.Clubs),
+            new Card(Rank.Four, Suit.Diamonds),
+            new Card(Rank.Six, Suit.Hearts)
+        });
+        var game = new HighLowGame(10, deck);
+        var result = game.Guess(GuessPrediction.High);
+        Assert.True(result.Correct);
+        Assert.Equal(Rank.Six, result.DrawnCard.Rank);
+    }
+}
+


### PR DESCRIPTION
## Summary
- introduce HighLowGame and service with `tmg lw` command
- wire up HighLowBackgroundLogic for interactive high/low rounds and streak payouts
- test HighLowGame logic and integrate into game background service

## Testing
- `dotnet format --include TsDiscordBot.Core/Amuse/AmuseCommandParser.cs TsDiscordBot.Core/HostedService/Amuse/GameBackgroundService.cs TsDiscordBot.Core/Amuse/PlayHighLowService.cs TsDiscordBot.Core/Game/HighLow/HighLowGame.cs TsDiscordBot.Core/HostedService/Amuse/HighLowBackgroundLogic.cs TsDiscordBot.Tests/HighLowGameTests.cs`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68c771c6c92c832da00d223b2f0107ad