### PR TITLE
Handle missing start message in amuse games

### DIFF
--- a/TsDiscordBot.Core/Amuse/PlayGameServiceBase.cs
+++ b/TsDiscordBot.Core/Amuse/PlayGameServiceBase.cs
@@ -95,6 +95,14 @@ public abstract class PlayGameServiceBase(int bet, DatabaseService databaseServi
             play.MessageId = reply.Id;
             DatabaseService.Update(AmusePlay.TableName, play);
         }
+        else
+        {
+            // If the start message could not be sent, refund the bet and remove the play
+            cash.Cash += bet;
+            cash.LastUpdatedAtUtc = DateTime.UtcNow;
+            DatabaseService.Update(AmuseCash.TableName, cash);
+            DatabaseService.Delete(AmusePlay.TableName, play.Id);
+        }
     }
 }
 

--- a/TsDiscordBot.Core/HostedService/Amuse/BlackJackBackgroundLoigic.cs
+++ b/TsDiscordBot.Core/HostedService/Amuse/BlackJackBackgroundLoigic.cs
@@ -183,6 +183,12 @@ namespace TsDiscordBot.Core.HostedService.Amuse
         {
             foreach (var play in amusePlays.Where(x => x.GameKind == "BJ" && !x.Started))
             {
+                if (play.MessageId == 0)
+                {
+                    _databaseService.Delete(AmusePlay.TableName, play.Id);
+                    continue;
+                }
+
                 if (_games.ContainsKey(play.MessageId))
                 {
                     continue;

--- a/TsDiscordBot.Core/HostedService/Amuse/DiceBackgroundLogic.cs
+++ b/TsDiscordBot.Core/HostedService/Amuse/DiceBackgroundLogic.cs
@@ -75,6 +75,12 @@ namespace TsDiscordBot.Core.HostedService.Amuse
         {
             foreach (var play in amusePlays.Where(x => x.GameKind == "DI"))
             {
+                if (play.MessageId == 0)
+                {
+                    _databaseService.Delete(AmusePlay.TableName, play.Id);
+                    continue;
+                }
+
                 if (!_diceGames.TryGetValue(play.MessageId, out var session))
                 {
                     if (play.Started)

--- a/TsDiscordBot.Core/HostedService/Amuse/HighLowBackgroundLogic.cs
+++ b/TsDiscordBot.Core/HostedService/Amuse/HighLowBackgroundLogic.cs
@@ -120,6 +120,12 @@ public class HighLowBackgroundLogic(DatabaseService databaseService, DiscordSock
     {
         foreach (var play in amusePlays.Where(x => x.GameKind == "HL" && !x.Started))
         {
+            if (play.MessageId == 0)
+            {
+                _databaseService.Delete(AmusePlay.TableName, play.Id);
+                continue;
+            }
+
             if (_sessions.ContainsKey(play.MessageId))
             {
                 continue;


### PR DESCRIPTION
## Summary
- refund bet and remove play when start message fails to send
- ignore invalid play records with missing message IDs in game processors

## Testing
- `dotnet format --include TsDiscordBot.Core/Amuse/PlayGameServiceBase.cs TsDiscordBot.Core/HostedService/Amuse/BlackJackBackgroundLoigic.cs TsDiscordBot.Core/HostedService/Amuse/DiceBackgroundLogic.cs TsDiscordBot.Core/HostedService/Amuse/HighLowBackgroundLogic.cs --verbosity diagnostic`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c7cb826188832dbf1961f42e711362