### PR TITLE
Use embeds for amuse leaderboards

### DIFF
--- a/TsDiscordBot.Core/Amuse/ShowRankService.cs
+++ b/TsDiscordBot.Core/Amuse/ShowRankService.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using System.Text;
+using Discord;
 using TsDiscordBot.Core.Framework;
 using TsDiscordBot.Core.Services;
 
@@ -58,6 +59,12 @@ public class ShowRankService : IAmuseService
             sb.AppendLine($"{rank + 1}. <@{below.UserId}>　{below.Cash}GAL円");
         }
 
-        return message.ReplyMessageAsync(sb.ToString().TrimEnd());
+        var embed = new EmbedBuilder()
+            .WithTitle("🏆 現在のランキング")
+            .WithDescription(sb.ToString().TrimEnd())
+            .WithColor(Color.Gold)
+            .Build();
+
+        return message.ReplyMessageAsync(embed, AllowedMentions.None);
     }
 }

--- a/TsDiscordBot.Core/Amuse/ShowTopCashService.cs
+++ b/TsDiscordBot.Core/Amuse/ShowTopCashService.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using System.Text;
+using Discord;
 using TsDiscordBot.Core.Framework;
 using TsDiscordBot.Core.Services;
 
@@ -34,6 +35,12 @@ public class ShowTopCashService : IAmuseService
             sb.AppendLine($"{rank}. <@{topUsers[i].UserId}>　{topUsers[i].Cash}GAL円");
         }
 
-        return message.ReplyMessageAsync(sb.ToString().TrimEnd());
+        var embed = new EmbedBuilder()
+            .WithTitle("💰 所持金ランキング TOP10")
+            .WithDescription(sb.ToString().TrimEnd())
+            .WithColor(Color.Gold)
+            .Build();
+
+        return message.ReplyMessageAsync(embed, AllowedMentions.None);
     }
 }

--- a/TsDiscordBot.Core/Amuse/ShowTopWinRateService.cs
+++ b/TsDiscordBot.Core/Amuse/ShowTopWinRateService.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using System.Text;
+using Discord;
 using TsDiscordBot.Core.Framework;
 using TsDiscordBot.Core.Services;
 
@@ -42,7 +43,13 @@ public class ShowTopWinRateService : IAmuseService
             sb.AppendLine($"{rank}. <@{r.UserId}>　{rate:0.##}% ({r.WinCount}/{r.TotalPlays})");
         }
 
-        return message.ReplyMessageAsync(sb.ToString().TrimEnd());
+        var embed = new EmbedBuilder()
+            .WithTitle($"🎮 {_gameName} 勝率 TOP10")
+            .WithDescription(sb.ToString().TrimEnd())
+            .WithColor(Color.Blue)
+            .Build();
+
+        return message.ReplyMessageAsync(embed, AllowedMentions.None);
     }
 }
 

--- a/TsDiscordBot.Core/Framework/IMessageData.cs
+++ b/TsDiscordBot.Core/Framework/IMessageData.cs
@@ -1,4 +1,6 @@
-﻿namespace TsDiscordBot.Core.Framework;
+﻿using Discord;
+
+namespace TsDiscordBot.Core.Framework;
 public record AttachmentData(string FileName, string ContentType, byte[] Bytes ,int? Width, int? Height);
 
 /// <summary>
@@ -30,7 +32,9 @@ public interface IMessageData
 
     public Task<bool> TryAddReactionAsync(string reaction);
     public Task<IMessageData?> SendMessageAsyncOnChannel(string content, string? filePath = null);
+    public Task<IMessageData?> SendMessageAsyncOnChannel(Embed embed, AllowedMentions? allowedMentions = null);
     public Task<IMessageData?> ReplyMessageAsync(string content, string? filePath = null);
+    public Task<IMessageData?> ReplyMessageAsync(Embed embed, AllowedMentions? allowedMentions = null);
     public Task<IMessageData?> ModifyMessageAsync(Func<string, string> modify);
     public Task<bool> DeleteAsync();
 

--- a/TsDiscordBot.Core/Framework/MessageData.cs
+++ b/TsDiscordBot.Core/Framework/MessageData.cs
@@ -121,12 +121,27 @@ public class MessageData : IMessageData
             return Task.FromResult<IMessageData?>(null);
         }
 
-        return SendMessageInternalAsync(message, Id, filePath);
+        return SendMessageInternalAsync(message, Id, filePath: filePath);
     }
 
-    public Task<IMessageData?> SendMessageAsyncOnChannel(string message,string? filePath = null)
+    public Task<IMessageData?> ReplyMessageAsync(Embed embed, AllowedMentions? allowedMentions = null)
     {
-        return SendMessageInternalAsync(message, null,filePath);
+        if (IsDeleted)
+        {
+            return Task.FromResult<IMessageData?>(null);
+        }
+
+        return SendMessageInternalAsync(null, Id, embed: embed, allowedMentions: allowedMentions);
+    }
+
+    public Task<IMessageData?> SendMessageAsyncOnChannel(string message, string? filePath = null)
+    {
+        return SendMessageInternalAsync(message, null, filePath: filePath);
+    }
+
+    public Task<IMessageData?> SendMessageAsyncOnChannel(Embed embed, AllowedMentions? allowedMentions = null)
+    {
+        return SendMessageInternalAsync(null, null, embed: embed, allowedMentions: allowedMentions);
     }
 
     public async Task<IMessageData?> ModifyMessageAsync(Func<string,string> modify)
@@ -158,7 +173,12 @@ public class MessageData : IMessageData
         return this;
     }
 
-    private async Task<IMessageData?> SendMessageInternalAsync(string content, ulong? referenceMessageId, string? filePath = null)
+    private async Task<IMessageData?> SendMessageInternalAsync(
+        string? content,
+        ulong? referenceMessageId,
+        string? filePath = null,
+        Embed? embed = null,
+        AllowedMentions? allowedMentions = null)
     {
         if (OriginalSocketMessage is null)
         {
@@ -178,11 +198,20 @@ public class MessageData : IMessageData
 
             if (filePath is not null)
             {
-                result = await OriginalSocketMessage.Channel.SendFileAsync(filePath,content, messageReference:reference);
+                result = await OriginalSocketMessage.Channel.SendFileAsync(
+                    filePath,
+                    content ?? string.Empty,
+                    embed: embed,
+                    allowedMentions: allowedMentions,
+                    messageReference: reference);
             }
             else
             {
-                result = await OriginalSocketMessage.Channel.SendMessageAsync(content, messageReference:reference);
+                result = await OriginalSocketMessage.Channel.SendMessageAsync(
+                    content,
+                    embed: embed,
+                    allowedMentions: allowedMentions,
+                    messageReference: reference);
             }
 
             return await FromIMessageAsync(result);

--- a/TsDiscordBot.Tests/AnonymousRelayServiceTests.cs
+++ b/TsDiscordBot.Tests/AnonymousRelayServiceTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using Discord;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using TsDiscordBot.Core.Data;
@@ -96,7 +97,9 @@ public class AnonymousRelayServiceTests
 
         public Task<bool> TryAddReactionAsync(string reaction) => Task.FromResult(true);
         public Task<IMessageData?> SendMessageAsyncOnChannel(string content, string? filePath = null) => Task.FromResult<IMessageData?>(null);
+        public Task<IMessageData?> SendMessageAsyncOnChannel(Embed embed, AllowedMentions? allowedMentions = null) => Task.FromResult<IMessageData?>(null);
         public Task<IMessageData?> ReplyMessageAsync(string content, string? filePath = null) => Task.FromResult<IMessageData?>(null);
+        public Task<IMessageData?> ReplyMessageAsync(Embed embed, AllowedMentions? allowedMentions = null) => Task.FromResult<IMessageData?>(null);
         public Task<IMessageData?> ModifyMessageAsync(Func<string, string> modify) => Task.FromResult<IMessageData?>(null);
         public Task<bool> DeleteAsync()
         {

--- a/TsDiscordBot.Tests/BannedMessageCheckerServiceTests.cs
+++ b/TsDiscordBot.Tests/BannedMessageCheckerServiceTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using System.Threading.Tasks;
+using Discord;
 using Discord.WebSocket;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -156,7 +157,13 @@ public class BannedMessageCheckerServiceTests
             SendMessageCalled = true;
             return Task.FromResult<IMessageData?>(null);
         }
+        public Task<IMessageData?> SendMessageAsyncOnChannel(Embed embed, AllowedMentions? allowedMentions = null)
+        {
+            SendMessageCalled = true;
+            return Task.FromResult<IMessageData?>(null);
+        }
         public Task<IMessageData?> ReplyMessageAsync(string content, string? filePath = null) => Task.FromResult<IMessageData?>(null);
+        public Task<IMessageData?> ReplyMessageAsync(Embed embed, AllowedMentions? allowedMentions = null) => Task.FromResult<IMessageData?>(null);
         public Task<IMessageData?> ModifyMessageAsync(Func<string, string> modify) => Task.FromResult<IMessageData?>(this);
         public Task<bool> DeleteAsync()
         {

--- a/TsDiscordBot.Tests/NauAriServiceTests.cs
+++ b/TsDiscordBot.Tests/NauAriServiceTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Discord;
 using Microsoft.Extensions.Logging.Abstractions;
 using TsDiscordBot.Core.Framework;
 using TsDiscordBot.Core.HostedService;
@@ -64,7 +65,11 @@ public class NauAriServiceTests
             SentMessage = content;
             return Task.FromResult<IMessageData?>(null);
         }
+        public Task<IMessageData?> SendMessageAsyncOnChannel(Embed embed, AllowedMentions? allowedMentions = null)
+            => Task.FromResult<IMessageData?>(null);
         public Task<IMessageData?> ReplyMessageAsync(string content, string? filePath = null) => Task.FromResult<IMessageData?>(null);
+        public Task<IMessageData?> ReplyMessageAsync(Embed embed, AllowedMentions? allowedMentions = null)
+            => Task.FromResult<IMessageData?>(null);
         public Task<IMessageData?> ModifyMessageAsync(Func<string, string> modify) => Task.FromResult<IMessageData?>(null);
         public Task<bool> DeleteAsync() => Task.FromResult(false);
         public Task CreateAttachmentSourceIfNotCachedAsync() => Task.CompletedTask;


### PR DESCRIPTION
## Summary
- render amuse rank/top leaderboards with embeds to avoid notifications
- extend the message helper to send embeds with mention suppression so leaderboards no longer ping users

## Testing
- dotnet format Develop.sln *(fails: command not found)*
- dotnet test Develop.sln *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c8e7facfa8832dac4c96d795555b59