### PR TITLE
Add High & Low win rate ranking support

### DIFF
--- a/TsDiscordBot.Core/Amuse/AmuseCommandParser.cs
+++ b/TsDiscordBot.Core/Amuse/AmuseCommandParser.cs
@@ -65,6 +65,13 @@ public class AmuseCommandParser : IAmuseCommandParser
                     {
                         return new ShowTopWinRateService("DI", "サイコロゲーム", _databaseService);
                     }
+
+                    if (parts[2].Equals("hl", StringComparison.OrdinalIgnoreCase) ||
+                        parts[2].Equals("highlow", StringComparison.OrdinalIgnoreCase) ||
+                        parts[2].Equals("highandlow", StringComparison.OrdinalIgnoreCase))
+                    {
+                        return new ShowTopWinRateService("HL", "ハイ＆ロー", _databaseService);
+                    }
                 }
 
                 return new ShowTopCashService(_databaseService);

--- a/TsDiscordBot.Core/Amuse/ShowWinRateService.cs
+++ b/TsDiscordBot.Core/Amuse/ShowWinRateService.cs
@@ -36,6 +36,7 @@ public class ShowWinRateService : IAmuseService
             {
                 "BJ" => "ブラックジャック",
                 "DI" => "サイコロゲーム",
+                "HL" => "ハイ＆ロー",
                 _ => record.GameKind
             };
             sb.AppendLine($"{gameName}: {rate:0.##}% ({record.WinCount}/{record.TotalPlays})");


### PR DESCRIPTION
## Summary
- enable the amuse top command to show High & Low win rate rankings
- label High & Low win rate results with the Japanese game name instead of the code

## Testing
- dotnet format *(fails: `dotnet` command not found in container)*
- dotnet test *(fails: `dotnet` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9694c8ec8832da5b94557adb3c73e