### PR TITLE
Fix dealer drawing logic after player busts

### DIFF
--- a/TsDiscordBot.Core/Game/BlackJack/BlackJackGame.cs
+++ b/TsDiscordBot.Core/Game/BlackJack/BlackJackGame.cs
@@ -104,7 +104,7 @@ public class BlackJackGame
 
     private void PlayDealerTurn()
     {
-        while (CalculateScore(_dealerHand) <= 17)
+        while (CalculateScore(_dealerHand) < 17)
         {
             _dealerHand.Add(_deck.Draw());
         }

--- a/TsDiscordBot.Core/Game/BlackJack/BlackJackGame.cs
+++ b/TsDiscordBot.Core/Game/BlackJack/BlackJackGame.cs
@@ -104,7 +104,7 @@ public class BlackJackGame
 
     private void PlayDealerTurn()
     {
-        while (CalculateScore(_dealerHand) < 17)
+        while (CalculateScore(_dealerHand) <= 17)
         {
             _dealerHand.Add(_deck.Draw());
         }

--- a/TsDiscordBot.Core/Game/BlackJack/BlackJackGame.cs
+++ b/TsDiscordBot.Core/Game/BlackJack/BlackJackGame.cs
@@ -51,6 +51,7 @@ public class BlackJackGame
         _playerHand.Add(_deck.Draw());
         if (CalculateScore(_playerHand) > 21)
         {
+            PlayDealerTurn();
             IsFinished = true;
             Result = BuildResult(GameOutcome.DealerWin);
         }
@@ -79,6 +80,7 @@ public class BlackJackGame
         _playerHand.Add(_deck.Draw());
         if (CalculateScore(_playerHand) > 21)
         {
+            PlayDealerTurn();
             IsFinished = true;
             Result = BuildResult(GameOutcome.DealerWin);
             return;
@@ -102,7 +104,7 @@ public class BlackJackGame
 
     private void PlayDealerTurn()
     {
-        while (CalculateScore(_dealerHand) < 17)
+        while (CalculateScore(_dealerHand) <= 17)
         {
             _dealerHand.Add(_deck.Draw());
         }

--- a/TsDiscordBot.Tests/BlackJackGameTests.cs
+++ b/TsDiscordBot.Tests/BlackJackGameTests.cs
@@ -25,6 +25,27 @@ public class BlackJackGameTests
     }
 
     [Fact]
+    public void Hit_Busts_DealerContinuesToDraw()
+    {
+        var deck = new Deck(new[]
+        {
+            new Card(Rank.Ten, Suit.Hearts),
+            new Card(Rank.Six, Suit.Spades),
+            new Card(Rank.Seven, Suit.Clubs),
+            new Card(Rank.Six, Suit.Hearts),
+            new Card(Rank.Ten, Suit.Diamonds),
+            new Card(Rank.Five, Suit.Clubs),
+            new Card(Rank.Four, Suit.Diamonds)
+        });
+        var game = new BlackJackGame(10, deck);
+        game.Hit();
+
+        Assert.True(game.IsFinished);
+        Assert.Equal(4, game.DealerCards.Count);
+        Assert.Equal(21, BlackJackGame.CalculateScore(game.DealerCards));
+    }
+
+    [Fact]
     public void Stand_PlayerHigherScore_Wins()
     {
         var deck = new Deck(new[]

--- a/TsDiscordBot.Tests/BlackJackGameTests.cs
+++ b/TsDiscordBot.Tests/BlackJackGameTests.cs
@@ -34,8 +34,8 @@ public class BlackJackGameTests
             new Card(Rank.Seven, Suit.Clubs),
             new Card(Rank.Six, Suit.Hearts),
             new Card(Rank.Ten, Suit.Diamonds),
-            new Card(Rank.Five, Suit.Clubs),
-            new Card(Rank.Four, Suit.Diamonds)
+            new Card(Rank.Four, Suit.Diamonds),
+            new Card(Rank.Five, Suit.Clubs)
         });
         var game = new BlackJackGame(10, deck);
         game.Hit();


### PR DESCRIPTION
## Summary
- ensure the dealer plays their turn even when the player busts by a hit or double down
- have the dealer continue hitting on totals of 17 or less
- add a regression test confirming the dealer keeps drawing after a player bust

## Testing
- dotnet format *(fails: dotnet CLI is unavailable in the execution environment)*
- dotnet test *(fails: dotnet CLI is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c969c6d1a8832dbca47aeffd926b80