### PR TITLE
Add messaging DTOs and update message data usage

### DIFF
--- a/TsDiscordBot.Core/Messaging/EmbedField.cs
+++ b/TsDiscordBot.Core/Messaging/EmbedField.cs
@@ -1,0 +1,3 @@
+namespace TsDiscordBot.Core.Messaging;
+
+public record EmbedField(string Name, string Value, bool Inline = false);

--- a/TsDiscordBot.Core/Messaging/MentionHandling.cs
+++ b/TsDiscordBot.Core/Messaging/MentionHandling.cs
@@ -1,0 +1,7 @@
+namespace TsDiscordBot.Core.Messaging;
+
+public enum MentionHandling
+{
+    Default,
+    SuppressAll,
+}

--- a/TsDiscordBot.Core/Messaging/MessageColor.cs
+++ b/TsDiscordBot.Core/Messaging/MessageColor.cs
@@ -1,0 +1,14 @@
+namespace TsDiscordBot.Core.Messaging;
+
+public readonly record struct MessageColor(byte R, byte G, byte B)
+{
+    public static MessageColor FromRgb(byte r, byte g, byte b) => new(r, g, b);
+
+    public static MessageColor FromHex(uint hex)
+    {
+        var r = (byte)((hex >> 16) & 0xFF);
+        var g = (byte)((hex >> 8) & 0xFF);
+        var b = (byte)(hex & 0xFF);
+        return new MessageColor(r, g, b);
+    }
+}

--- a/TsDiscordBot.Core/Messaging/MessageEmbed.cs
+++ b/TsDiscordBot.Core/Messaging/MessageEmbed.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+
+namespace TsDiscordBot.Core.Messaging;
+
+public class MessageEmbed
+{
+    public string? Title { get; init; }
+    public string? Description { get; init; }
+    public MessageColor? Color { get; init; }
+    public string? ImageUrl { get; init; }
+    public IReadOnlyList<EmbedField> Fields { get; init; } = System.Array.Empty<EmbedField>();
+}

--- a/TsDiscordBot.Core/Messaging/MessageSendOptions.cs
+++ b/TsDiscordBot.Core/Messaging/MessageSendOptions.cs
@@ -1,0 +1,9 @@
+namespace TsDiscordBot.Core.Messaging;
+
+public class MessageSendOptions
+{
+    public string? Content { get; init; }
+    public string? FilePath { get; init; }
+    public MessageEmbed? Embed { get; init; }
+    public MentionHandling MentionHandling { get; init; } = MentionHandling.Default;
+}

--- a/TsDiscordBot.Discord/Amuse/ShowRankService.cs
+++ b/TsDiscordBot.Discord/Amuse/ShowRankService.cs
@@ -1,5 +1,5 @@
 using System.Text;
-using Discord;
+using TsDiscordBot.Core.Messaging;
 using TsDiscordBot.Discord.Framework;
 using TsDiscordBot.Discord.Services;
 
@@ -58,12 +58,17 @@ public class ShowRankService : IAmuseService
             sb.AppendLine($"{rank + 1}. <@{below.UserId}>　{below.Cash}GAL円");
         }
 
-        var embed = new EmbedBuilder()
-            .WithTitle("🏆 現在のランキング")
-            .WithDescription(sb.ToString().TrimEnd())
-            .WithColor(Color.Gold)
-            .Build();
+        var options = new MessageSendOptions
+        {
+            Embed = new MessageEmbed
+            {
+                Title = "🏆 現在のランキング",
+                Description = sb.ToString().TrimEnd(),
+                Color = MessageColor.FromHex(0xFFD700),
+            },
+            MentionHandling = MentionHandling.SuppressAll,
+        };
 
-        return message.ReplyMessageAsync(embed, AllowedMentions.None);
+        return message.ReplyMessageAsync(options);
     }
 }

--- a/TsDiscordBot.Discord/Amuse/ShowTopCashService.cs
+++ b/TsDiscordBot.Discord/Amuse/ShowTopCashService.cs
@@ -1,5 +1,5 @@
 using System.Text;
-using Discord;
+using TsDiscordBot.Core.Messaging;
 using TsDiscordBot.Discord.Framework;
 using TsDiscordBot.Discord.Services;
 
@@ -34,12 +34,17 @@ public class ShowTopCashService : IAmuseService
             sb.AppendLine($"{rank}. <@{topUsers[i].UserId}>　{topUsers[i].Cash}GAL円");
         }
 
-        var embed = new EmbedBuilder()
-            .WithTitle("💰 所持金ランキング TOP10")
-            .WithDescription(sb.ToString().TrimEnd())
-            .WithColor(Color.Gold)
-            .Build();
+        var options = new MessageSendOptions
+        {
+            Embed = new MessageEmbed
+            {
+                Title = "💰 所持金ランキング TOP10",
+                Description = sb.ToString().TrimEnd(),
+                Color = MessageColor.FromHex(0xFFD700),
+            },
+            MentionHandling = MentionHandling.SuppressAll,
+        };
 
-        return message.ReplyMessageAsync(embed, AllowedMentions.None);
+        return message.ReplyMessageAsync(options);
     }
 }

--- a/TsDiscordBot.Discord/Amuse/ShowTopWinRateService.cs
+++ b/TsDiscordBot.Discord/Amuse/ShowTopWinRateService.cs
@@ -1,5 +1,5 @@
 using System.Text;
-using Discord;
+using TsDiscordBot.Core.Messaging;
 using TsDiscordBot.Discord.Framework;
 using TsDiscordBot.Discord.Services;
 
@@ -42,13 +42,18 @@ public class ShowTopWinRateService : IAmuseService
             sb.AppendLine($"{rank}. <@{r.UserId}>　{rate:0.##}% ({r.WinCount}/{r.TotalPlays})");
         }
 
-        var embed = new EmbedBuilder()
-            .WithTitle($"🎮 {_gameName} 勝率 TOP10")
-            .WithDescription(sb.ToString().TrimEnd())
-            .WithColor(Color.Blue)
-            .Build();
+        var options = new MessageSendOptions
+        {
+            Embed = new MessageEmbed
+            {
+                Title = $"🎮 {_gameName} 勝率 TOP10",
+                Description = sb.ToString().TrimEnd(),
+                Color = MessageColor.FromHex(0x0000FF),
+            },
+            MentionHandling = MentionHandling.SuppressAll,
+        };
 
-        return message.ReplyMessageAsync(embed, AllowedMentions.None);
+        return message.ReplyMessageAsync(options);
     }
 }
 

--- a/TsDiscordBot.Discord/Framework/IMessageData.cs
+++ b/TsDiscordBot.Discord/Framework/IMessageData.cs
@@ -1,4 +1,4 @@
-﻿using Discord;
+﻿using TsDiscordBot.Core.Messaging;
 
 namespace TsDiscordBot.Discord.Framework;
 public record AttachmentData(string FileName, string ContentType, byte[] Bytes ,int? Width, int? Height);
@@ -32,9 +32,9 @@ public interface IMessageData
 
     public Task<bool> TryAddReactionAsync(string reaction);
     public Task<IMessageData?> SendMessageAsyncOnChannel(string content, string? filePath = null);
-    public Task<IMessageData?> SendMessageAsyncOnChannel(Embed embed, AllowedMentions? allowedMentions = null);
+    public Task<IMessageData?> SendMessageAsyncOnChannel(MessageSendOptions options);
     public Task<IMessageData?> ReplyMessageAsync(string content, string? filePath = null);
-    public Task<IMessageData?> ReplyMessageAsync(Embed embed, AllowedMentions? allowedMentions = null);
+    public Task<IMessageData?> ReplyMessageAsync(MessageSendOptions options);
     public Task<IMessageData?> ModifyMessageAsync(Func<string, string> modify);
     public Task<bool> DeleteAsync();
 

--- a/TsDiscordBot.Tests/AnonymousRelayServiceTests.cs
+++ b/TsDiscordBot.Tests/AnonymousRelayServiceTests.cs
@@ -2,8 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using Discord;
 using Microsoft.Extensions.Logging.Abstractions;
+using TsDiscordBot.Core.Messaging;
 using TsDiscordBot.Discord.Data;
 using TsDiscordBot.Discord.Framework;
 using TsDiscordBot.Discord.HostedService;
@@ -101,9 +101,9 @@ public class AnonymousRelayServiceTests
 
         public Task<bool> TryAddReactionAsync(string reaction) => Task.FromResult(true);
         public Task<IMessageData?> SendMessageAsyncOnChannel(string content, string? filePath = null) => Task.FromResult<IMessageData?>(null);
-        public Task<IMessageData?> SendMessageAsyncOnChannel(Embed embed, AllowedMentions? allowedMentions = null) => Task.FromResult<IMessageData?>(null);
+        public Task<IMessageData?> SendMessageAsyncOnChannel(MessageSendOptions options) => Task.FromResult<IMessageData?>(null);
         public Task<IMessageData?> ReplyMessageAsync(string content, string? filePath = null) => Task.FromResult<IMessageData?>(null);
-        public Task<IMessageData?> ReplyMessageAsync(Embed embed, AllowedMentions? allowedMentions = null) => Task.FromResult<IMessageData?>(null);
+        public Task<IMessageData?> ReplyMessageAsync(MessageSendOptions options) => Task.FromResult<IMessageData?>(null);
         public Task<IMessageData?> ModifyMessageAsync(Func<string, string> modify) => Task.FromResult<IMessageData?>(null);
         public Task<bool> DeleteAsync()
         {

--- a/TsDiscordBot.Tests/BannedMessageCheckerServiceTests.cs
+++ b/TsDiscordBot.Tests/BannedMessageCheckerServiceTests.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Discord;
 using Discord.WebSocket;
 using Microsoft.Extensions.Logging.Abstractions;
+using TsDiscordBot.Core.Messaging;
 using TsDiscordBot.Discord.Data;
 using TsDiscordBot.Discord.Framework;
 using TsDiscordBot.Discord.HostedService;
@@ -154,13 +155,13 @@ public class BannedMessageCheckerServiceTests
             SendMessageCalled = true;
             return Task.FromResult<IMessageData?>(null);
         }
-        public Task<IMessageData?> SendMessageAsyncOnChannel(Embed embed, AllowedMentions? allowedMentions = null)
+        public Task<IMessageData?> SendMessageAsyncOnChannel(MessageSendOptions options)
         {
             SendMessageCalled = true;
             return Task.FromResult<IMessageData?>(null);
         }
         public Task<IMessageData?> ReplyMessageAsync(string content, string? filePath = null) => Task.FromResult<IMessageData?>(null);
-        public Task<IMessageData?> ReplyMessageAsync(Embed embed, AllowedMentions? allowedMentions = null) => Task.FromResult<IMessageData?>(null);
+        public Task<IMessageData?> ReplyMessageAsync(MessageSendOptions options) => Task.FromResult<IMessageData?>(null);
         public Task<IMessageData?> ModifyMessageAsync(Func<string, string> modify) => Task.FromResult<IMessageData?>(this);
         public Task<bool> DeleteAsync()
         {

--- a/TsDiscordBot.Tests/NauAriServiceTests.cs
+++ b/TsDiscordBot.Tests/NauAriServiceTests.cs
@@ -2,8 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using Discord;
 using Microsoft.Extensions.Logging.Abstractions;
+using TsDiscordBot.Core.Messaging;
 using TsDiscordBot.Discord.Framework;
 using TsDiscordBot.Discord.HostedService;
 using Xunit;
@@ -63,10 +63,10 @@ public class NauAriServiceTests
             SentMessage = content;
             return Task.FromResult<IMessageData?>(null);
         }
-        public Task<IMessageData?> SendMessageAsyncOnChannel(Embed embed, AllowedMentions? allowedMentions = null)
+        public Task<IMessageData?> SendMessageAsyncOnChannel(MessageSendOptions options)
             => Task.FromResult<IMessageData?>(null);
         public Task<IMessageData?> ReplyMessageAsync(string content, string? filePath = null) => Task.FromResult<IMessageData?>(null);
-        public Task<IMessageData?> ReplyMessageAsync(Embed embed, AllowedMentions? allowedMentions = null)
+        public Task<IMessageData?> ReplyMessageAsync(MessageSendOptions options)
             => Task.FromResult<IMessageData?>(null);
         public Task<IMessageData?> ModifyMessageAsync(Func<string, string> modify) => Task.FromResult<IMessageData?>(null);
         public Task<bool> DeleteAsync() => Task.FromResult(false);


### PR DESCRIPTION
## Summary
- add Discord-agnostic messaging DTOs for embeds, colors, and mention handling in TsDiscordBot.Core
- update IMessageData and MessageData to translate the new MessageSendOptions into Discord.NET objects
- refactor amuse services and unit tests to construct the new DTOs instead of EmbedBuilder/AllowedMentions

## Testing
- dotnet format *(fails: command not found)*
- dotnet test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ca8bce32a0832d9d3c8254dc42f6ef