### PR TITLE
Format TMG cash amounts with thousand separators

### DIFF
--- a/TsDiscordBot.Discord/Amuse/ShowCashService.cs
+++ b/TsDiscordBot.Discord/Amuse/ShowCashService.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using TsDiscordBot.Core.Messaging;
 using TsDiscordBot.Discord.Framework;
 using TsDiscordBot.Discord.Services;
@@ -20,7 +21,8 @@ public class ShowCashService : IAmuseService
             .FirstOrDefault(x => x.UserId == message.AuthorId);
 
         var amount = cash?.Cash ?? 0;
-        return message.ReplyMessageAsync($"{message.AuthorMention}さんは現在{amount}GAL円を保持しています。");
+        var formattedAmount = amount.ToString("N0", CultureInfo.InvariantCulture);
+        return message.ReplyMessageAsync($"{message.AuthorMention}さんは現在`{formattedAmount}` GAL円を保持しています。");
     }
 }
 

--- a/TsDiscordBot.Discord/Amuse/ShowTopCashService.cs
+++ b/TsDiscordBot.Discord/Amuse/ShowTopCashService.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text;
 using Discord.WebSocket;
 using TsDiscordBot.Core.Messaging;
@@ -43,7 +44,8 @@ public class ShowTopCashService : IAmuseService
         for (var i = 0; i < topUsers.Length; i++)
         {
             var rank = i + 1;
-            sb.AppendLine($"{rank}. <@{topUsers[i].UserId}>　{topUsers[i].Cash}GAL円");
+            var formattedCash = topUsers[i].Cash.ToString("N0", CultureInfo.InvariantCulture);
+            sb.AppendLine($"{rank}. <@{topUsers[i].UserId}>　`{formattedCash}` GAL円");
         }
 
         var options = new MessageSendOptions


### PR DESCRIPTION
## Summary
- format TMG cash display with thousand separators
- wrap GAL yen amounts in inline code blocks and add spacing for readability

## Testing
- `dotnet format` *(fails: dotnet command not available in container)*
- `dotnet test` *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd67e663a8832d8f65f90891bce2de