### PR TITLE
Fix blackjack push when both players bust

### DIFF
--- a/TsDiscordBot.Core/Game/BlackJack/BlackJackGame.cs
+++ b/TsDiscordBot.Core/Game/BlackJack/BlackJackGame.cs
@@ -48,7 +48,7 @@ public class BlackJackGame
         {
             PlayDealerTurn();
             IsFinished = true;
-            Result = BuildResult(GameOutcome.DealerWin);
+            Result = BuildResult(DetermineOutcome());
         }
     }
 
@@ -77,7 +77,7 @@ public class BlackJackGame
         {
             PlayDealerTurn();
             IsFinished = true;
-            Result = BuildResult(GameOutcome.DealerWin);
+            Result = BuildResult(DetermineOutcome());
             return;
         }
 

--- a/TsDiscordBot.Tests/BlackJackGameTests.cs
+++ b/TsDiscordBot.Tests/BlackJackGameTests.cs
@@ -46,6 +46,25 @@ public class BlackJackGameTests
     }
 
     [Fact]
+    public void Hit_BothBusts_ResultsInPush()
+    {
+        var deck = new Deck([
+            new Card(Rank.Ten, Suit.Hearts),
+            new Card(Rank.Seven, Suit.Spades),
+            new Card(Rank.Nine, Suit.Clubs),
+            new Card(Rank.Seven, Suit.Hearts),
+            new Card(Rank.King, Suit.Diamonds),
+            new Card(Rank.Nine, Suit.Diamonds)
+        ]);
+        var game = new BlackJackGame(10, deck);
+        game.Hit();
+
+        Assert.True(game.IsFinished);
+        Assert.Equal(GameOutcome.Push, game.Result!.Outcome);
+        Assert.Equal(10, game.Result.Payout);
+    }
+
+    [Fact]
     public void Stand_PlayerHigherScore_Wins()
     {
         var deck = new Deck([


### PR DESCRIPTION
## Summary
- ensure player bust flows evaluate the full game outcome instead of assuming a dealer win
- add a regression test covering the scenario where both the player and dealer bust and should push

## Testing
- dotnet test *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd6e5ccaac832dbf578f0d596b6de2