### PR TITLE
Fix blackjack dealer card display mismatch

### DIFF
--- a/TsDiscordBot.Discord/HostedService/Amuse/BlackJackState/BlackJackUIBuilder.cs
+++ b/TsDiscordBot.Discord/HostedService/Amuse/BlackJackState/BlackJackUIBuilder.cs
@@ -101,7 +101,7 @@ namespace TsDiscordBot.Discord.HostedService.Amuse.BlackJackState
 
             if (_game.IsFinished)
             {
-                cards.Append(_emoteDatabase.GetEmote(_game.PlayerCards[0]));
+                cards.Append(_emoteDatabase.GetEmote(_game.DealerCards[0]));
                 for (int i = 1; i < _game.DealerCards.Count; i++)
                 {
                     var card = _game.DealerCards[i];


### PR DESCRIPTION
## Summary
- ensure the dealer's revealed hand uses the dealer cards when the game is finished to keep the displayed emotes in sync with the score

## Testing
- dotnet format *(fails: command not found in container)*
- dotnet test *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cfdb0b1178832da4420d3488eddb31