### PR TITLE
Ensure oversea relay caches attachments before deletion

### DIFF
--- a/TsDiscordBot.Discord/HostedService/OverseaRelayService.cs
+++ b/TsDiscordBot.Discord/HostedService/OverseaRelayService.cs
@@ -92,6 +92,8 @@ public class OverseaRelayService : IHostedService
             avatarUrl = message.AvatarUrl;
         }
 
+        await message.CreateAttachmentSourceIfNotCachedAsync();
+
         List<Task> tasks =
         [
             Task.Run(async () =>


### PR DESCRIPTION
## Summary
- ensure oversea relay downloads attachment data before scheduling message deletion to keep anonymous file relays working

## Testing
- dotnet test *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d65dcb6fa0832da1e540961477e08b