### PR TITLE
Streamline High & Low win decisions

### DIFF
--- a/TsDiscordBot.Discord/HostedService/Amuse/HighLowState/HighLowActions.cs
+++ b/TsDiscordBot.Discord/HostedService/Amuse/HighLowState/HighLowActions.cs
@@ -4,8 +4,7 @@ public static class HighLowActions
 {
     public const string High = "empty_hl_high";
     public const string Low = "empty_hl_low";
-    public const string Continue = "empty_hl_continue";
-    public const string Stop = "empty_hl_stop";
+    public const string Drop = "empty_hl_drop";
     public const string Replay = "empty_hl_replay";
     public const string Quit = "empty_hl_quit";
 }

--- a/TsDiscordBot.Discord/HostedService/Amuse/HighLowState/HighLowGuessState.cs
+++ b/TsDiscordBot.Discord/HostedService/Amuse/HighLowState/HighLowGuessState.cs
@@ -69,7 +69,7 @@ public class HighLowGuessGameState : IGameState
                 }
 
                 return Task.FromResult<IGameState>(
-                    new HighLowDecisionWinState(
+                    new HighLowWinState(
                         _context,
                         previous,
                         result.DrawnCard));

--- a/TsDiscordBot.Discord/HostedService/Amuse/HighLowState/HighLowUiBuilder.cs
+++ b/TsDiscordBot.Discord/HostedService/Amuse/HighLowState/HighLowUiBuilder.cs
@@ -10,7 +10,7 @@ namespace TsDiscordBot.Discord.HostedService.Amuse.HighLowState
         private readonly ulong _messageId;
 
         private bool _enableHighLowButton;
-        private bool _enableContinueButton;
+        private bool _enableDropButton;
         private bool _enableRetryButton;
 
         private string? _header;
@@ -52,9 +52,9 @@ namespace TsDiscordBot.Discord.HostedService.Amuse.HighLowState
             return this;
         }
 
-        public HighLowUiBuilder EnableContinueButton()
+        public HighLowUiBuilder EnableDropButton()
         {
-            _enableContinueButton = true;
+            _enableDropButton = true;
             return this;
         }
 
@@ -95,10 +95,9 @@ namespace TsDiscordBot.Discord.HostedService.Amuse.HighLowState
                 yield return Button(HighLowActions.High, "ハイ", ButtonStyle.Primary);
                 yield return Button(HighLowActions.Low, "ロー", ButtonStyle.Secondary);
             }
-            if (_enableContinueButton)
+            if (_enableDropButton)
             {
-                yield return Button(HighLowActions.Continue, "続ける", ButtonStyle.Primary);
-                yield return Button(HighLowActions.Stop, "終了", ButtonStyle.Secondary);
+                yield return Button(HighLowActions.Drop, "ドロップ", ButtonStyle.Secondary);
             }
 
             if (_enableRetryButton)

--- a/TsDiscordBot.Discord/HostedService/Amuse/HighLowState/HighLowWinState.cs
+++ b/TsDiscordBot.Discord/HostedService/Amuse/HighLowState/HighLowWinState.cs
@@ -5,13 +5,13 @@ using TsDiscordBot.Core.Messaging;
 
 namespace TsDiscordBot.Discord.HostedService.Amuse.HighLowState;
 
-public class HighLowDecisionWinState : IGameState
+public class HighLowWinState : IGameState
 {
     private readonly HighLowGameContext _context;
     private readonly Card _previousCard;
     private readonly Card _drawnCard;
 
-    public HighLowDecisionWinState(HighLowGameContext context, Card previousCard, Card drawnCard)
+    public HighLowWinState(HighLowGameContext context, Card previousCard, Card drawnCard)
     {
         _context = context;
         _previousCard = previousCard;
@@ -75,7 +75,7 @@ public class HighLowDecisionWinState : IGameState
                 }
 
                 return Task.FromResult<IGameState>(
-                    new HighLowDecisionWinState(
+                    new HighLowWinState(
                         _context,
                         previous,
                         result.DrawnCard));

--- a/TsDiscordBot.Discord/HostedService/Amuse/HighLowState/HighLowWinState.cs
+++ b/TsDiscordBot.Discord/HostedService/Amuse/HighLowState/HighLowWinState.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using TsDiscordBot.Core.Game;
+using TsDiscordBot.Core.Game.HighLow;
 using TsDiscordBot.Core.Messaging;
 
 namespace TsDiscordBot.Discord.HostedService.Amuse.HighLowState;
@@ -31,9 +32,9 @@ public class HighLowDecisionWinState : IGameState
         string title = $"正解！ 連勝数 {_context.Game.Streak}";
         StringBuilder description = new StringBuilder();
         description.AppendLine($"次に正解すると {_context.Game.CalculateNextStreakPayout()} GAL円");
-        description.AppendLine($"ここでやめると {_context.Game.CalculatePayout()} GAL円");
+        description.AppendLine($"ドロップすると {_context.Game.CalculatePayout()} GAL円");
 
-        string footer = "ゲームを続行する？";
+        string footer = "ハイかローで続行、ドロップで終了";
 
         string? currentCard = _context.EmoteDatabase.FindEmoteByCard(_previousCard, false)?.Url;
         string? nextCard = _context.EmoteDatabase.FindEmoteByCard(_drawnCard, false)?.Url;
@@ -46,7 +47,8 @@ public class HighLowDecisionWinState : IGameState
             .WithCard(currentCard)
             .WithNextCard(nextCard)
             .WithColor(MessageColor.FromRgb(184, 210, 0))
-            .EnableContinueButton()
+            .EnableHighLowButton()
+            .EnableDropButton()
             .Build();
 
         return Task.FromResult(result);
@@ -54,11 +56,48 @@ public class HighLowDecisionWinState : IGameState
 
     public Task<IGameState> GetNextStateAsync(string actionId)
     {
-        return actionId switch
+        if (actionId == HighLowActions.High || actionId == HighLowActions.Low)
         {
-            HighLowActions.Continue => Task.FromResult<IGameState>(new HighLowGuessGameState(_context)),
-            HighLowActions.Stop => Task.FromResult<IGameState>(new HighLowResultState(_context,_previousCard,_drawnCard, _context.Game.CalculatePayout())),
-            _ => Task.FromResult<IGameState>(this)
-        };
+            var prediction = actionId == HighLowActions.High ? GuessPrediction.High : GuessPrediction.Low;
+            var previous = _context.Game.CurrentCard;
+            var result = _context.Game.Guess(prediction);
+
+            if (result.Correct)
+            {
+                if (result.MaxReached)
+                {
+                    return Task.FromResult<IGameState>(
+                        new HighLowResultState(
+                            _context,
+                            previous,
+                            result.DrawnCard,
+                            _context.Game.CalculatePayout()));
+                }
+
+                return Task.FromResult<IGameState>(
+                    new HighLowDecisionWinState(
+                        _context,
+                        previous,
+                        result.DrawnCard));
+            }
+
+            return Task.FromResult<IGameState>(
+                new HighLowDecisionLoseState(
+                    _context,
+                    previous,
+                    result.DrawnCard));
+        }
+
+        if (actionId == HighLowActions.Drop)
+        {
+            return Task.FromResult<IGameState>(
+                new HighLowResultState(
+                    _context,
+                    _previousCard,
+                    _drawnCard,
+                    _context.Game.CalculatePayout()));
+        }
+
+        return Task.FromResult<IGameState>(this);
     }
 }


### PR DESCRIPTION
## Summary
- replace the post-win continue/stop prompt with direct High/Low/Drop choices
- add a drop action and button builder support so the win state can both continue and cash out
- execute the next guess directly from the win state when High or Low is chosen

## Testing
- `dotnet format` *(fails: command not found in container)*
- `dotnet test` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d65f9e5678832d97982950fecdf180